### PR TITLE
uqamar/VisaTrack-Core#3: CI: Enable GitHub CodeQL and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "develop"
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "develop"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
codeql.yml: triggers now run on pushes/PRs targeting develop instead of main.
dependabot.yml: Dependabot PRs now target develop.

## 📝 Description
1️⃣ CodeQL
Go to GitHub → Security → Code scanning
You should see:
CodeQL workflow runs
Results after first run (may say “No vulnerabilities found”)

2️⃣ Dependabot
Go to GitHub → Security → Dependabot
You should see:
Dependency graph enabled
Alerts (if any)
Dependabot will open PRs automatically when updates are available

## 🔗 Linked Issue
https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/3
Closes #

## ✅ Checklist
- [ ] My code follows the project's style guidelines.
- [ ] I have linked the relevant issue using "Closes #X".
- [ ] I have requested exactly 1 reviewer.
- [ ] I have verified that the build passes locally.

## 📸 Screenshots (if applicable)
