### PR TITLE
backend test coverage added

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
 
       - name: Build frontend
         working-directory: frontend
@@ -61,8 +65,14 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      - name: Compile backend
+        working-directory: backend
+        run: |
+          source venv/bin/activate
+          python -m compileall app
+
       - name: Run backend tests
         working-directory: backend
         run: |
           source venv/bin/activate
-          pytest || test $? -eq 5
+          pytest tests -q

--- a/backend/tests/api/deps/test_auth_deps.py
+++ b/backend/tests/api/deps/test_auth_deps.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.deps import auth as auth_deps
+from tests.support import FakeResult, row
+
+
+def test_get_auth_context_success(monkeypatch, make_user):
+    user = make_user()
+    db = MagicMock()
+    db.scalar.return_value = user
+    db.execute.return_value = FakeResult([
+        row(slug='lawyer', permissions=['cases:view']),
+        row(slug='LAWYER', permissions=['documents:view']),
+    ])
+    monkeypatch.setattr(
+        auth_deps,
+        'decode_access_token',
+        lambda token: {'sub': str(user.id), 'org': str(user.organization_id), 'roles': ['client']},
+    )
+    credentials = row(scheme='Bearer', credentials='token')
+
+    result = auth_deps.get_auth_context(credentials=credentials, db=db)
+
+    assert result.user is user
+    assert set(result.roles) == {'client', 'lawyer'}
+    assert result.permissions == {'cases:view', 'documents:view'}
+
+
+def test_get_auth_context_rejects_locked_user(monkeypatch, make_user):
+    user = make_user(locked_until=datetime.now(timezone.utc) + timedelta(minutes=5))
+    db = MagicMock()
+    db.scalar.return_value = user
+    db.execute.return_value = FakeResult([])
+    monkeypatch.setattr(
+        auth_deps,
+        'decode_access_token',
+        lambda token: {'sub': str(user.id), 'org': str(user.organization_id), 'roles': []},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        auth_deps.get_auth_context(credentials=row(scheme='Bearer', credentials='token'), db=db)
+
+    assert exc.value.status_code == 401
+    assert 'locked' in exc.value.detail.lower()
+
+
+def test_require_roles_and_permissions(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'], permissions={'documents:view'})
+
+    assert auth_deps.require_roles('lawyer')(auth) is auth
+    assert auth_deps.require_permissions('documents:view')(auth) is auth
+
+    with pytest.raises(HTTPException):
+        auth_deps.require_roles('client')(auth)
+
+    with pytest.raises(HTTPException):
+        auth_deps.require_permissions('cases:edit')(auth)

--- a/backend/tests/api/routes/test_admin.py
+++ b/backend/tests/api/routes/test_admin.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import admin
+from app.schemas.admin import AdminAssignRoleRequest, AdminCreateUserRequest
+from tests.support import FakeResult, row
+
+
+def test_admin_helpers_normalize_and_scope(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+
+    assert admin._slugify('Acme Law LLP') == 'acme-law-llp'
+    assert admin._normalize_email(' USER@EXAMPLE.COM ') == 'user@example.com'
+
+    with pytest.raises(HTTPException):
+        admin._require_org_scope(auth, uuid4())
+
+
+def test_get_admin_overview_returns_expected_payload(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    now = datetime.now(timezone.utc)
+    db = MagicMock()
+    db.scalar.side_effect = [1, 2, 1, 3, 1]
+    db.execute.side_effect = [
+        FakeResult([row(id=uuid4(), name='Acme', slug='acme', contact_email='hello@acme.com', subscription_status='active', created_at=now)]),
+        FakeResult([row(id=uuid4(), organization_id=auth.organization_id, email='user@example.com', first_name='User', last_name='One', status='active', created_at=now)]),
+        FakeResult([row(id=uuid4(), case_number='C-1', case_type='Express Entry', status='intake', priority='medium', created_at=now, first_name='Client', last_name='One')]),
+    ]
+
+    result = admin.get_admin_overview(auth=auth, db=db)
+
+    assert result.stats.active_cases == 3
+    assert result.recent_cases[0].client_name == 'Client One'
+
+
+def test_create_organization_rejects_duplicate_slug(make_auth_context):
+    auth = make_auth_context(roles=['super_admin'], permissions={'*'})
+    db = MagicMock()
+    db.scalar.return_value = uuid4()
+    payload = row(name='Acme', contact_email='hello@acme.com', slug='acme', subscription_tier='basic', subscription_status='active')
+
+    with pytest.raises(HTTPException) as exc:
+        admin.create_organization(payload=payload, auth=auth, db=db)
+
+    assert exc.value.status_code == 409
+
+
+def test_list_admin_organizations_returns_scoped_rows(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'], permissions={'settings:view'})
+    now = datetime.now(timezone.utc)
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = [
+        row(
+            id=auth.organization_id,
+            name='Acme Law',
+            slug='acme-law',
+            contact_email='hello@acme.com',
+            subscription_tier='basic',
+            subscription_status='active',
+            created_at=now,
+            updated_at=now,
+            deleted_at=None,
+        )
+    ]
+
+    result = admin.list_admin_organizations(limit=25, offset=0, auth=auth, db=db)
+
+    assert len(result) == 1
+    assert result[0].slug == 'acme-law'
+
+
+def test_list_roles_returns_available_roles(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'], permissions={'roles:manage'})
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = [
+        row(
+            id=uuid4(),
+            organization_id=None,
+            name='Lawyer',
+            slug='lawyer',
+            description='Case lawyer',
+            is_system=True,
+            permissions=['cases:manage'],
+        )
+    ]
+
+    result = admin.list_roles(auth=auth, db=db)
+
+    assert result[0].slug == 'lawyer'
+    assert result[0].permissions == ['cases:manage']
+
+
+def test_create_user_assigns_role_and_returns_item(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['org_admin'], permissions={'users:manage'})
+    db = MagicMock()
+    db.scalar.side_effect = [auth.organization_id, None]
+
+    created_objects = []
+
+    def capture_add(obj):
+        created_objects.append(obj)
+
+    def flush_side_effect():
+        for obj in created_objects:
+            if getattr(obj, 'id', None) is None:
+                obj.id = uuid4()
+            if getattr(obj, 'created_at', None) is None:
+                obj.created_at = datetime.now(timezone.utc)
+
+    db.add.side_effect = capture_add
+    db.flush.side_effect = flush_side_effect
+    db.refresh.side_effect = lambda obj: None
+
+    assigned = []
+    monkeypatch.setattr(admin, 'hash_password', lambda value: f'hashed:{value}')
+    monkeypatch.setattr(
+        admin,
+        'assign_role_to_user',
+        lambda db, user_id, role_slug, assigned_by: assigned.append((user_id, role_slug, assigned_by)),
+    )
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    payload = AdminCreateUserRequest(
+        organization_id=auth.organization_id,
+        email='client@example.com',
+        first_name='Client',
+        last_name='User',
+        password='Password123',
+        status='active',
+        role_slug='client',
+    )
+
+    result = admin.create_user(payload=payload, auth=auth, db=db)
+
+    assert result.email == 'client@example.com'
+    assert result.full_name == 'Client User'
+    assert assigned[0][1] == 'client'
+
+
+def test_assign_user_role_assigns_and_commits(monkeypatch, make_auth_context, make_user):
+    auth = make_auth_context(roles=['org_admin'], permissions={'users:manage', 'roles:manage'})
+    existing_user = make_user(organization_id=auth.organization_id)
+    db = MagicMock()
+    db.scalar.return_value = existing_user
+
+    assigned = []
+    monkeypatch.setattr(
+        admin,
+        'assign_role_to_user',
+        lambda db, user_id, role_slug, assigned_by: assigned.append((user_id, role_slug, assigned_by)),
+    )
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    admin.assign_user_role(
+        user_id=existing_user.id,
+        payload=AdminAssignRoleRequest(role_slug='lawyer'),
+        auth=auth,
+        db=db,
+    )
+
+    assert assigned == [(existing_user.id, 'lawyer', auth.user_id)]
+    db.commit.assert_called_once()

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import auth
+from app.schemas.auth import AcceptInvitationRequest, ChangePasswordRequest, LoginRequest, UpdateCurrentUserSettingsRequest
+from tests.support import FakeResult, row
+
+
+def test_auth_helpers_normalize_and_detect_onboarding(make_user):
+    user = make_user()
+    db = MagicMock()
+    db.scalar.return_value = None
+
+    assert auth._normalize_email(' USER@EXAMPLE.COM ') == 'user@example.com'
+    assert auth._lawyer_onboarding_required(db, user, ['lawyer']) is True
+
+
+def test_login_rejects_locked_account(monkeypatch, make_user):
+    organization = row(id=uuid4(), slug='acme')
+    user = make_user(organization_id=organization.id, locked_until=datetime.now(timezone.utc) + timedelta(minutes=5))
+    db = MagicMock()
+    db.scalar.side_effect = [organization, user]
+
+    with pytest.raises(HTTPException) as exc:
+        auth.login(payload=row(organization_slug='acme', email='user@example.com', password='secret'), db=db)
+
+    assert exc.value.status_code == 423
+
+
+def test_login_invalid_password_increments_attempts(monkeypatch, make_user):
+    organization = row(id=uuid4(), slug='acme')
+    user = make_user(organization_id=organization.id, login_attempts=1)
+    db = MagicMock()
+    db.scalar.side_effect = [organization, user]
+    monkeypatch.setattr(auth, 'verify_password', lambda password, stored_hash: False)
+
+    with pytest.raises(HTTPException) as exc:
+        auth.login(payload=row(organization_slug='acme', email='user@example.com', password='bad'), db=db)
+
+    assert exc.value.status_code == 401
+    assert user.login_attempts == 2
+    db.commit.assert_called_once()
+
+
+def test_me_returns_current_user_payload(monkeypatch, make_auth_context):
+    auth_context = make_auth_context(roles=['lawyer'])
+    db = MagicMock()
+    monkeypatch.setattr(auth, '_lawyer_onboarding_required', lambda db, user, roles: True)
+
+    result = auth.me(auth=auth_context, db=db)
+
+    assert result.email == auth_context.user.email
+    assert result.onboarding_required is True
+
+
+def test_update_me_settings_rejects_duplicate_email(make_auth_context):
+    auth_context = make_auth_context()
+    db = MagicMock()
+    db.scalar.return_value = uuid4()
+    payload = row(email='taken@example.com', first_name=None, last_name=None, phone=None, avatar_url=None, mfa_enabled=None, timezone=None, locale=None)
+
+    with pytest.raises(HTTPException) as exc:
+        auth.update_me_settings(payload=payload, auth=auth_context, db=db)
+
+    assert exc.value.status_code == 409
+
+
+def test_login_success_returns_access_token(monkeypatch, make_user):
+    organization = row(id=uuid4(), slug='acme')
+    user = make_user(organization_id=organization.id, status='active')
+    db = MagicMock()
+    db.scalar.side_effect = [organization, user]
+    db.execute.return_value = FakeResult(rows=['lawyer'])
+    monkeypatch.setattr(auth, 'verify_password', lambda password, stored_hash: True)
+    monkeypatch.setattr(auth, 'create_access_token', lambda user_id, org_id, roles: 'token-123')
+
+    result = auth.login(
+        payload=LoginRequest(organization_slug='acme', email='user@example.com', password='secret'),
+        db=db,
+    )
+
+    assert result.access_token == 'token-123'
+    assert user.login_attempts == 0
+    db.commit.assert_called_once()
+
+
+def test_me_settings_returns_current_user_settings(make_auth_context):
+    auth_context = make_auth_context()
+
+    result = auth.me_settings(auth=auth_context)
+
+    assert result.email == auth_context.user.email
+    assert result.timezone == auth_context.user.timezone
+
+
+def test_update_me_settings_updates_fields_and_clears_mfa_secret(monkeypatch, make_auth_context):
+    auth_context = make_auth_context()
+    auth_context.user.mfa_secret = 'secret'
+    db = MagicMock()
+    db.scalar.return_value = None
+    db.refresh.side_effect = lambda obj: None
+    monkeypatch.setattr(auth, 'log_activity', lambda *args, **kwargs: None)
+
+    result = auth.update_me_settings(
+        payload=UpdateCurrentUserSettingsRequest(
+            email='updated@example.com',
+            first_name='Updated',
+            last_name='User',
+            phone='555-0100',
+            avatar_url='https://example.com/a.png',
+            mfa_enabled=False,
+            timezone='America/Vancouver',
+            locale='fr-CA',
+        ),
+        auth=auth_context,
+        db=db,
+    )
+
+    assert result.email == 'updated@example.com'
+    assert auth_context.user.mfa_secret is None
+    db.commit.assert_called_once()
+
+
+def test_change_password_updates_hash(monkeypatch, make_auth_context):
+    auth_context = make_auth_context()
+    db = MagicMock()
+    monkeypatch.setattr(auth, 'verify_password', lambda current, stored: True)
+    monkeypatch.setattr(auth, 'hash_password', lambda password: f'hashed:{password}')
+
+    auth.change_password(
+        payload=ChangePasswordRequest(current_password='old-password', new_password='NewPassword123'),
+        auth=auth_context,
+        db=db,
+    )
+
+    assert auth_context.user.password_hash == 'hashed:NewPassword123'
+    db.commit.assert_called_once()
+
+
+def test_accept_invitation_activates_user_and_creates_profile(monkeypatch, make_user):
+    invitation = row(
+        organization_id=uuid4(),
+        user_id=uuid4(),
+        role_slug='client',
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        accepted_at=None,
+        revoked_at=None,
+    )
+    user = make_user(id=invitation.user_id, organization_id=invitation.organization_id, status='invited')
+    db = MagicMock()
+    db.scalar.side_effect = [invitation, user, None]
+    monkeypatch.setattr(auth, 'hash_invitation_token', lambda token: 'token-hash')
+    monkeypatch.setattr(auth, 'hash_password', lambda password: 'hashed-password')
+
+    result = auth.accept_invitation(
+        payload=AcceptInvitationRequest(token='a' * 16, password='Password123'),
+        db=db,
+    )
+
+    assert result.email == user.email
+    assert user.status == 'active'
+    db.commit.assert_called_once()

--- a/backend/tests/api/routes/test_cases.py
+++ b/backend/tests/api/routes/test_cases.py
@@ -1,0 +1,652 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from app.api.routes import cases
+from app.schemas.case import (
+    CaseCreateRequest,
+    CaseCustomDocumentCreateRequest,
+    CaseCustomDocumentSuiteCreateRequest,
+    CaseDetailsUpdateRequest,
+    CaseDocumentRenameRequest,
+    CaseDocumentStatusUpdateRequest,
+    CaseDocumentUploadCompleteRequest,
+    CaseDocumentUploadInitiateRequest,
+    CaseMessageCreateRequest,
+    CaseMilestoneCreateRequest,
+    CaseMilestoneUpdateRequest,
+    CasePortalPermissionsUpdateRequest,
+)
+from tests.support import FakeResult, row
+
+
+def test_case_helper_normalizers_and_sanitizers():
+    normalized = cases._normalized_portal_permissions({'portal_access': 'READ_ONLY', 'document_upload': 'disabled'})
+    custom_docs = cases._normalized_custom_documents([
+        {'id': 'doc-1', 'name': 'Passport', 'required': True, 'status': 'under review'},
+        {'id': '', 'name': 'Ignored'},
+    ])
+
+    assert normalized['portal_access'] == 'read_only'
+    assert normalized['document_upload'] == 'disabled'
+    assert custom_docs == [
+        {
+            'id': 'doc-1',
+            'name': 'Passport',
+            'suite_id': None,
+            'required': True,
+            'due_date': None,
+            'instructions': None,
+            'status': 'under_review',
+        }
+    ]
+    assert cases._sanitize_file_name(' My File?.pdf ') == 'My_File_.pdf'
+
+
+def test_archive_name_generation_handles_duplicates():
+    seen = {}
+
+    first = cases._archive_entry_name(base_name='Passport Scan', original_file_name='passport.pdf', seen_names=seen)
+    second = cases._archive_entry_name(base_name='Passport Scan', original_file_name='passport.pdf', seen_names=seen)
+
+    assert first == 'Passport_Scan.pdf'
+    assert second == 'Passport_Scan (2).pdf'
+
+
+def test_client_portal_capabilities_respect_permissions(make_auth_context):
+    case = type('CaseStub', (), {'custom_fields': {'portal_permissions': {'portal_access': 'read_only', 'document_upload': 'enabled', 'show_document_requirements': True}}})()
+
+    capabilities = cases._client_portal_capabilities(case)
+
+    assert capabilities['can_view_documents'] is True
+    assert capabilities['can_upload_documents'] is False
+
+
+def test_create_case_returns_created_case(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    client_user = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        first_name='Client',
+        last_name='One',
+    )
+    lawyer_user = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        first_name='Law',
+        last_name='Yer',
+    )
+    db = MagicMock()
+    db.scalar.side_effect = [auth.organization_id, client_user, lawyer_user, None]
+
+    created_objects = []
+
+    def capture_add(obj):
+        created_objects.append(obj)
+
+    def flush_side_effect():
+        for obj in created_objects:
+            if getattr(obj, 'id', None) is None:
+                obj.id = uuid4()
+            if getattr(obj, 'created_at', None) is None:
+                obj.created_at = datetime.now(timezone.utc)
+
+    db.add.side_effect = capture_add
+    db.flush.side_effect = flush_side_effect
+    db.refresh.side_effect = lambda obj: None
+    monkeypatch.setattr(cases, '_generate_case_number', lambda db, organization_id: 'C-2026-010')
+
+    result = cases.create_case(
+        payload=CaseCreateRequest(
+            organization_id=auth.organization_id,
+            client_id=client_user.id,
+            primary_lawyer_id=lawyer_user.id,
+            case_type='Express Entry',
+            status='intake',
+            priority='medium',
+            description='Case description',
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.case_number == 'C-2026-010'
+    assert result.client_name == 'Client One'
+    assert result.primary_lawyer_name == 'Law Yer'
+
+
+def test_list_cases_returns_joined_rows(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_number='C-2026-001',
+        case_type='Express Entry',
+        status='intake',
+        priority='medium',
+        target_filing_date=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db = MagicMock()
+    db.execute.return_value.all.return_value = [(case, 'Client', 'One', 'Law', 'Yer')]
+
+    result = cases.list_cases(limit=25, offset=0, auth=auth, db=db)
+
+    assert result[0].case_number == 'C-2026-001'
+    assert result[0].primary_lawyer_name == 'Law Yer'
+
+
+def test_get_case_by_number_returns_summary(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(
+        id=uuid4(),
+        case_number='C-2026-001',
+        case_type='Express Entry',
+        status='intake',
+        priority='medium',
+        target_filing_date=None,
+        estimated_completion_from=None,
+        estimated_completion_to=None,
+        description='Desc',
+        internal_notes='Notes',
+    )
+    milestone = row(
+        id=uuid4(),
+        name='Collect passport',
+        status='in_progress',
+        due_date=None,
+        completion_percentage=60,
+    )
+    db = MagicMock()
+    db.execute.side_effect = [
+        FakeResult(rows=[(case, 'Client', 'One', 'Law', 'Yer')]),
+        FakeResult(rows=[milestone]),
+    ]
+
+    result = cases.get_case_by_number(case_number='C-2026-001', auth=auth, db=db)
+
+    assert result.case_number == 'C-2026-001'
+    assert result.milestones[0].name == 'Collect passport'
+
+
+def test_update_case_details_by_number_updates_case(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        client_id=uuid4(),
+        case_number='C-2026-001',
+        case_type='Old Type',
+        priority='low',
+        status='intake',
+        target_filing_date=None,
+        description=None,
+        internal_notes=None,
+        updated_at=datetime.now(timezone.utc),
+    )
+    db = MagicMock()
+    db.refresh.side_effect = lambda obj: None
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.update_case_details_by_number(
+        case_number='C-2026-001',
+        payload=CaseDetailsUpdateRequest(
+            case_type='Express Entry',
+            priority='high',
+            status='submitted',
+            target_filing_date=date(2026, 2, 28),
+            description='Updated',
+            internal_notes='Internal',
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'submitted'
+    assert case.case_type == 'Express Entry'
+    db.commit.assert_called_once()
+
+
+def test_create_case_milestone_returns_workspace_milestone(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=uuid4())
+    inserted_row = {
+        'id': uuid4(),
+        'name': 'Gather docs',
+        'description': 'Collect required files',
+        'status': 'in_progress',
+        'due_date': None,
+        'completion_percentage': 60,
+        'client_visible': True,
+        'depends_on': [],
+        'completed_at': None,
+    }
+    db = MagicMock()
+    db.execute.side_effect = [
+        FakeResult(scalar_value=1),
+        FakeResult(rows=[inserted_row]),
+    ]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.create_case_milestone(
+        case_number='C-2026-001',
+        payload=CaseMilestoneCreateRequest(name='Gather docs', description='Collect required files', status='in_progress'),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.name == 'Gather docs'
+    assert result.status == 'in_progress'
+
+
+def test_update_case_milestone_returns_updated_row(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=uuid4())
+    milestone_id = str(uuid4())
+    existing_row = {
+        'id': uuid4(),
+        'name': 'Old',
+        'description': None,
+        'status': 'not_started',
+        'due_date': None,
+        'completion_percentage': 0,
+        'client_visible': True,
+        'depends_on': [],
+        'completed_by': None,
+        'completed_at': None,
+    }
+    updated_row = {
+        'id': existing_row['id'],
+        'name': 'New',
+        'description': 'Updated',
+        'status': 'completed',
+        'due_date': None,
+        'completion_percentage': 100,
+        'client_visible': False,
+        'depends_on': [],
+        'completed_at': datetime.now(timezone.utc),
+    }
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[existing_row]), FakeResult(rows=[updated_row])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.update_case_milestone(
+        case_number='C-2026-001',
+        milestone_id=milestone_id,
+        payload=CaseMilestoneUpdateRequest(name='New', description='Updated', status='completed', client_visible=False),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.name == 'New'
+    assert result.completion_percentage == 100
+
+
+def test_delete_case_milestone_commits(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=uuid4())
+    db = MagicMock()
+    db.execute.return_value = FakeResult(
+        rows=[{'id': uuid4(), 'name': 'Old milestone', 'status': 'blocked', 'due_date': None, 'client_visible': True}]
+    )
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    cases.delete_case_milestone(
+        case_number='C-2026-001',
+        milestone_id=str(uuid4()),
+        auth=auth,
+        db=db,
+    )
+
+    db.commit.assert_called_once()
+
+
+def test_create_case_message_returns_message(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=uuid4())
+    inserted_row = {
+        'id': uuid4(),
+        'subject': 'Need passport',
+        'body': 'Please upload it.',
+        'sent_at': datetime.now(timezone.utc),
+        'read_at': None,
+    }
+    db = MagicMock()
+    db.execute.return_value = FakeResult(rows=[inserted_row])
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.create_case_message(
+        case_number='C-2026-001',
+        payload=CaseMessageCreateRequest(subject='Need passport', body='Please upload it.', visible_to_client=True),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.subject == 'Need passport'
+    assert result.from_client is False
+
+
+def test_get_case_workspace_by_number_returns_workspace(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case_row = {
+        'id': uuid4(),
+        'organization_id': auth.organization_id,
+        'client_id': uuid4(),
+        'primary_lawyer_id': auth.user_id,
+        'created_by': auth.user_id,
+        'case_number': 'C-2026-001',
+        'case_type': 'Express Entry',
+        'status': 'intake',
+        'priority': 'medium',
+        'start_date': None,
+        'target_filing_date': None,
+        'estimated_completion_from': None,
+        'estimated_completion_to': None,
+        'completion_confidence': None,
+        'description': 'Desc',
+        'internal_notes': 'Notes',
+        'custom_fields': {},
+        'client_name': 'Client One',
+        'primary_lawyer_name': 'Law Yer',
+    }
+    document_rows = [
+        {
+            'suite_id': uuid4(),
+            'suite_name': 'Identity',
+            'suite_description': 'Identity docs',
+            'suite_is_system': True,
+            'template_id': uuid4(),
+            'template_name': 'Passport',
+            'instructions': 'Upload a copy',
+            'is_required': True,
+            'latest_case_document_id': None,
+            'doc_status': 'pending',
+            'uploaded_at': None,
+            'expiry_date': None,
+            'file_name': None,
+        }
+    ]
+    billing_row = {'total_fees': 0, 'total_paid': 0, 'total_remaining': 0, 'next_payment_due': None}
+    db = MagicMock()
+    db.execute.side_effect = [
+        FakeResult(rows=[case_row]),
+        FakeResult(rows=document_rows),
+        FakeResult(rows=[]),
+        FakeResult(rows=[]),
+        FakeResult(rows=[]),
+        FakeResult(rows=[]),
+        FakeResult(rows=[billing_row]),
+        FakeResult(rows=[]),
+        FakeResult(rows=[]),
+    ]
+
+    result = cases.get_case_workspace_by_number(case_number='C-2026-001', auth=auth, db=db)
+
+    assert result.case.case_number == 'C-2026-001'
+    assert result.document_suites[0].documents[0].name == 'Passport'
+
+
+def test_update_case_portal_permissions_persists_custom_fields(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, custom_fields={})
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    result = cases.update_case_portal_permissions(
+        case_number='C-2026-001',
+        payload=CasePortalPermissionsUpdateRequest(
+            show_case_status_progress=False,
+            show_milestone_details=True,
+            show_document_requirements=True,
+            portal_access='limited_access',
+            document_upload='disabled',
+            messaging='one_way',
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.portal_access == 'limited_access'
+    assert case.custom_fields['portal_permissions']['document_upload'] == 'disabled'
+
+
+def test_create_case_custom_document_suite_adds_suite(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, custom_fields={})
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    result = cases.create_case_custom_document_suite(
+        case_number='C-2026-001',
+        payload=CaseCustomDocumentSuiteCreateRequest(name='Additional Docs', description='Extra'),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.name == 'Additional Docs'
+    assert case.custom_fields['custom_document_suites'][0]['name'] == 'Additional Docs'
+
+
+def test_create_case_custom_document_adds_document(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=uuid4(), custom_fields={})
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.create_case_custom_document(
+        case_number='C-2026-001',
+        payload=CaseCustomDocumentCreateRequest(name='National ID', required=True, instructions='Both sides'),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.name == 'National ID'
+    assert case.custom_fields['custom_documents'][0]['name'] == 'National ID'
+
+
+def test_rename_case_document_updates_name_override(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        client_id=uuid4(),
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Old Name', 'required': True}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    result = cases.rename_case_document(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentRenameRequest(name='New Name'),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.name == 'New Name'
+    assert case.custom_fields['document_name_overrides'][document_id] == 'New Name'
+
+
+def test_delete_case_document_hides_document(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        client_id=uuid4(),
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Old Name', 'required': True}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+
+    cases.delete_case_document(
+        case_number='C-2026-001',
+        document_id=document_id,
+        auth=auth,
+        db=db,
+    )
+
+    assert document_id in case.custom_fields['hidden_document_ids']
+    db.commit.assert_called_once()
+
+
+def test_update_case_document_status_updates_custom_document(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'pending'}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    result = cases.update_case_document_status(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentStatusUpdateRequest(status='approved'),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'approved'
+    assert case.custom_fields['custom_documents'][0]['status'] == 'approved'
+
+
+def test_initiate_case_document_upload_returns_presigned_upload(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, custom_fields={})
+    slot = {
+        'logical_document_id': str(uuid4()),
+        'name': 'Passport',
+        'required': True,
+        'instructions': 'Upload passport',
+    }
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, '_resolve_document_slot', lambda **kwargs: slot)
+    monkeypatch.setattr(cases, 'create_presigned_upload', lambda **kwargs: row(url='https://upload', headers={'Content-Type': 'application/pdf'}, expires_in_seconds=900))
+
+    result = cases.initiate_case_document_upload(
+        case_number='C-2026-001',
+        document_id=slot['logical_document_id'],
+        payload=CaseDocumentUploadInitiateRequest(file_name='passport.pdf', file_type='application/pdf', file_size_bytes=1024),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.upload_url == 'https://upload'
+    assert result.storage_key.startswith(f'org/{auth.organization_id}/case/{case.id}/documents/')
+
+
+def test_complete_case_document_upload_records_upload(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    document_id = str(uuid4())
+    case = row(id=uuid4(), organization_id=auth.organization_id, client_id=auth.user_id, custom_fields={})
+    slot = {
+        'kind': 'template',
+        'logical_document_id': document_id,
+        'template_id': document_id,
+        'name': 'Passport',
+        'required': True,
+        'instructions': 'Upload passport',
+        'previous_case_document_id': None,
+        'next_version': 1,
+    }
+    storage_key = f'org/{case.organization_id}/case/{case.id}/documents/{document_id}/uuid-passport.pdf'
+    db = MagicMock()
+    db.execute.return_value = FakeResult(rows=[{'id': uuid4(), 'uploaded_at': datetime.now(timezone.utc)}])
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, '_resolve_document_slot', lambda **kwargs: slot)
+    monkeypatch.setattr(cases, 'head_object', lambda **kwargs: {'ContentLength': 1024, 'ContentType': 'application/pdf'})
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+    monkeypatch.setattr(cases, 'log_document_access', lambda *args, **kwargs: None)
+
+    result = cases.complete_case_document_upload(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentUploadCompleteRequest(
+            storage_key=storage_key,
+            file_name='passport.pdf',
+            file_type='application/pdf',
+            file_size_bytes=1024,
+        ),
+        request=row(client=row(host='127.0.0.1'), headers={'user-agent': 'pytest'}),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'received'
+    assert result.can_download is True
+
+
+def test_get_case_document_download_url_returns_presigned_link(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), organization_id=auth.organization_id, custom_fields={})
+    slot = {
+        'logical_document_id': str(uuid4()),
+        'name': 'Passport',
+        'bound_case_document': {
+            'id': uuid4(),
+            'file_path': 'org/x/doc.pdf',
+            'file_name': 'passport.pdf',
+        },
+    }
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, '_resolve_document_slot', lambda **kwargs: slot)
+    monkeypatch.setattr(cases, 'create_presigned_download', lambda **kwargs: 'https://download')
+    monkeypatch.setattr(cases, 'log_document_access', lambda *args, **kwargs: None)
+
+    result = cases.get_case_document_download_url(
+        case_number='C-2026-001',
+        document_id=slot['logical_document_id'],
+        request=row(client=row(host='127.0.0.1'), headers={'user-agent': 'pytest'}),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.download_url == 'https://download'
+    assert result.file_name == 'passport.pdf'
+
+
+def test_download_all_case_documents_returns_zip(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(id=uuid4(), case_number='C-2026-001', organization_id=auth.organization_id, custom_fields={})
+    db = MagicMock()
+    db.execute.side_effect = [
+        FakeResult(rows=[{'id': uuid4(), 'name': 'Passport', 'file_name': 'passport.pdf', 'file_path': 'path/passport.pdf', 'uploaded_at': datetime.now(timezone.utc)}]),
+        FakeResult(rows=[]),
+    ]
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, 'get_object_bytes', lambda **kwargs: b'file-bytes')
+    monkeypatch.setattr(cases, 'log_document_access', lambda *args, **kwargs: None)
+
+    response = cases.download_all_case_documents(
+        case_number='C-2026-001',
+        request=row(client=row(host='127.0.0.1'), headers={'user-agent': 'pytest'}),
+        auth=auth,
+        db=db,
+    )
+
+    assert response.media_type == 'application/zip'
+    assert response.headers['Content-Disposition'].endswith('"C-2026-001-documents.zip"')

--- a/backend/tests/api/routes/test_client.py
+++ b/backend/tests/api/routes/test_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes.client import get_client_case, list_client_cases
+from tests.support import FakeResult, row
+
+
+def test_list_client_cases_returns_joined_case_rows(make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    case = row(id=uuid4(), case_number='C-2026-001', case_type='Express Entry', status='intake', priority='medium', target_filing_date=None, created_at=datetime.now(timezone.utc))
+    db = MagicMock()
+    db.execute.return_value = FakeResult([(case, 'Ava', 'Lawyer')])
+
+    result = list_client_cases(auth=auth, db=db)
+
+    assert len(result) == 1
+    assert result[0].primary_lawyer_name == 'Ava Lawyer'
+
+
+def test_get_client_case_raises_when_missing(make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    db = MagicMock()
+    db.execute.return_value = FakeResult([])
+
+    with pytest.raises(HTTPException) as exc:
+        get_client_case('C-2026-001', auth=auth, db=db)
+
+    assert exc.value.status_code == 404

--- a/backend/tests/api/routes/test_dashboard.py
+++ b/backend/tests/api/routes/test_dashboard.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.api.routes.dashboard import get_dashboard_overview
+from tests.support import FakeResult, row
+
+
+def test_dashboard_overview_aggregates_counts(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    db = MagicMock()
+    db.scalar.side_effect = [2, 5, 3, 1]
+    db.execute.side_effect = [
+        FakeResult([row(id=uuid4(), case_number='C-1', case_type='Express Entry', status='intake', priority='high', first_name='Client', last_name='One')]),
+        FakeResult([row(id=uuid4(), case_id=uuid4(), case_number='C-1', name='Review', due_date=None, status='not_started')]),
+    ]
+
+    result = get_dashboard_overview(auth=auth, db=db)
+
+    assert result.stats.organizations == 2
+    assert result.stats.users == 5
+    assert result.recent_cases[0].client_name == 'Client One'
+    assert result.upcoming_milestones[0].name == 'Review'

--- a/backend/tests/api/routes/test_health.py
+++ b/backend/tests/api/routes/test_health.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from app.api.routes.health import health, root_health
+
+
+def test_health_endpoints_return_ok():
+    assert root_health() == {'status': 'ok'}
+    assert health() == {'status': 'ok'}

--- a/backend/tests/api/routes/test_lawyer.py
+++ b/backend/tests/api/routes/test_lawyer.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api.routes import lawyer
+from app.schemas.lawyer import (
+    InviteClientRequest,
+    LawyerCaseCreateRequest,
+    LawyerClientCreateRequest,
+    LawyerProfileUpsertRequest,
+)
+from tests.support import FakeResult, row
+
+
+def test_lawyer_helpers_normalize_and_increment_case_numbers():
+    db = MagicMock()
+    db.execute.return_value = FakeResult(scalar_value=7)
+
+    assert lawyer._normalize_email(' USER@EXAMPLE.COM ') == 'user@example.com'
+    assert lawyer._case_number_next(db, uuid4()).endswith('008')
+
+
+def test_get_lawyer_profile_returns_empty_state_without_profile(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    db = MagicMock()
+    db.scalar.return_value = None
+
+    result = lawyer.get_lawyer_profile(auth=auth, db=db)
+
+    assert result.onboarding_complete is False
+    assert result.specialties == []
+
+
+def test_list_lawyer_clients_formats_names(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    user = row(
+        id=uuid4(),
+        email='client@example.com',
+        first_name='Client',
+        last_name='One',
+        status='active',
+        organization_id=auth.organization_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = [user]
+
+    result = lawyer.list_lawyer_clients(search=None, limit=50, offset=0, auth=auth, db=db)
+
+    assert result[0].full_name == 'Client One'
+
+
+def test_create_lawyer_client_creates_invited_client(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    db = MagicMock()
+    db.scalar.return_value = None
+
+    created_objects = []
+
+    def capture_add(obj):
+        created_objects.append(obj)
+
+    def flush_side_effect():
+        for obj in created_objects:
+            if getattr(obj, 'id', None) is None:
+                obj.id = uuid4()
+
+    db.add.side_effect = capture_add
+    db.flush.side_effect = flush_side_effect
+    monkeypatch.setattr(lawyer, 'hash_password', lambda value: f'hashed:{value}')
+    monkeypatch.setattr(lawyer, 'generate_invitation_token', lambda: 'invite-token')
+    monkeypatch.setattr(lawyer, 'hash_invitation_token', lambda token: f'hash:{token}')
+    monkeypatch.setattr(lawyer, 'assign_role_to_user', lambda *args, **kwargs: None)
+    monkeypatch.setattr(lawyer, 'log_activity', lambda *args, **kwargs: None)
+
+    result = lawyer.create_lawyer_client(
+        payload=LawyerClientCreateRequest(
+            email='client@example.com',
+            first_name='Client',
+            last_name='One',
+            send_invite=True,
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'invited'
+    assert 'invite?token=invite-token' in result.invitation_url
+    db.commit.assert_called_once()
+
+
+def test_upsert_lawyer_profile_returns_completed_profile(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    db = MagicMock()
+    db.scalar.return_value = None
+    monkeypatch.setattr(lawyer, 'log_activity', lambda *args, **kwargs: None)
+
+    result = lawyer.upsert_lawyer_profile(
+        payload=LawyerProfileUpsertRequest(
+            bar_number='BAR-123',
+            jurisdiction='Ontario',
+            specialties=['Express Entry', '  '],
+            years_experience=5,
+            bio='Immigration lawyer',
+            hourly_rate=250.0,
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.onboarding_complete is True
+    assert result.specialties == ['Express Entry']
+    db.commit.assert_called_once()
+
+
+def test_list_lawyer_cases_returns_case_rows(make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_number='C-2026-001',
+        case_type='Express Entry',
+        status='intake',
+        priority='medium',
+        primary_lawyer_id=auth.user_id,
+        target_filing_date=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db = MagicMock()
+    db.execute.return_value.all.return_value = [(case, 'Client', 'One')]
+
+    result = lawyer.list_lawyer_cases(limit=50, offset=0, auth=auth, db=db)
+
+    assert result[0].case_number == 'C-2026-001'
+    assert result[0].client_name == 'Client One'
+
+
+def test_create_lawyer_case_creates_case_and_primary_case_client(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    client_user = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        first_name='Client',
+        last_name='One',
+    )
+    db = MagicMock()
+    db.scalar.return_value = client_user
+
+    created_objects = []
+
+    def capture_add(obj):
+        created_objects.append(obj)
+
+    def flush_side_effect():
+        for obj in created_objects:
+            if getattr(obj, 'id', None) is None:
+                obj.id = uuid4()
+            if getattr(obj, 'created_at', None) is None:
+                obj.created_at = datetime.now(timezone.utc)
+
+    db.add.side_effect = capture_add
+    db.flush.side_effect = flush_side_effect
+    db.refresh.side_effect = lambda obj: None
+    monkeypatch.setattr(lawyer, '_case_number_next', lambda db, organization_id: 'C-2026-009')
+    monkeypatch.setattr(lawyer, 'log_activity', lambda *args, **kwargs: None)
+
+    result = lawyer.create_lawyer_case(
+        payload=LawyerCaseCreateRequest(
+            client_user_id=client_user.id,
+            case_type='Express Entry',
+            priority='medium',
+            description='New matter',
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.case_number == 'C-2026-009'
+    assert result.primary_lawyer_name == f'{auth.user.first_name} {auth.user.last_name}'
+
+
+def test_invite_client_to_case_returns_invitation(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    case = row(
+        id=uuid4(),
+        case_number='C-2026-001',
+        organization_id=auth.organization_id,
+        primary_lawyer_id=auth.user_id,
+        created_by=auth.user_id,
+    )
+    invited_user = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        email='client@example.com',
+        first_name='Client',
+        last_name='One',
+        status='invited',
+    )
+    db = MagicMock()
+    db.scalar.side_effect = [case, invited_user, None]
+    monkeypatch.setattr(lawyer, 'assign_role_to_user', lambda *args, **kwargs: None)
+    monkeypatch.setattr(lawyer, 'generate_invitation_token', lambda: 'invite-token')
+    monkeypatch.setattr(lawyer, 'hash_invitation_token', lambda token: f'hash:{token}')
+    monkeypatch.setattr(lawyer, 'log_activity', lambda *args, **kwargs: None)
+
+    result = lawyer.invite_client_to_case(
+        case_number='C-2026-001',
+        payload=InviteClientRequest(
+            email='client@example.com',
+            first_name='Client',
+            last_name='One',
+            relationship_type='related',
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.case_number == 'C-2026-001'
+    assert result.client_email == 'client@example.com'
+    assert result.invitation_url.endswith('invite?token=invite-token')

--- a/backend/tests/api/routes/test_organizations.py
+++ b/backend/tests/api/routes/test_organizations.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.api.routes.organizations import list_organizations
+from tests.support import row
+
+
+def test_list_organizations_limits_to_auth_org(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = [row(id=auth.organization_id, name='Firm', slug='firm', contact_email='a@b.com', subscription_status='active', created_at=datetime.now(timezone.utc))]
+
+    result = list_organizations(limit=25, offset=0, auth=auth, db=db)
+
+    stmt = db.scalars.call_args[0][0]
+    assert 'organizations.id = :id_1' in str(stmt)
+    assert len(result) == 1

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.api.routes.users import list_users
+from tests.support import row
+
+
+def test_list_users_uses_org_scope_for_org_admin(make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    db = MagicMock()
+    user = row(id=auth.user_id, email='user@example.com', first_name='Test', last_name='User', status='active', organization_id=auth.organization_id, created_at=datetime.now(timezone.utc))
+    db.scalars.return_value.all.return_value = [user]
+
+    result = list_users(limit=25, offset=0, auth=auth, db=db)
+
+    stmt = db.scalars.call_args[0][0]
+    assert 'users.organization_id = :organization_id_1' in str(stmt)
+    assert result[0].email == 'user@example.com'
+
+
+def test_list_users_allows_super_admin_org_filter(make_auth_context):
+    auth = make_auth_context(roles=['super_admin'])
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = []
+
+    list_users(organization_id=auth.organization_id, limit=25, offset=0, auth=auth, db=db)
+
+    stmt = db.scalars.call_args[0][0]
+    assert 'users.organization_id = :organization_id_1' in str(stmt)

--- a/backend/tests/api/test_router.py
+++ b/backend/tests/api/test_router.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from app.api.router import api_router
+
+
+def test_api_router_includes_expected_paths():
+    paths = {route.path for route in api_router.routes}
+
+    assert '/health' in paths
+    assert '/api/v1/auth/login' in paths
+    assert '/api/v1/cases/by-number/{case_number}/workspace' in paths
+    assert '/api/v1/lawyer/clients' in paths

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.api.deps.auth import AuthContext
+
+
+@pytest.fixture
+def make_user():
+    def _make_user(**overrides):
+        defaults = {
+            'id': uuid4(),
+            'organization_id': uuid4(),
+            'email': 'user@example.com',
+            'first_name': 'Test',
+            'last_name': 'User',
+            'status': 'active',
+            'password_hash': 'secret',
+            'login_attempts': 0,
+            'locked_until': None,
+            'last_login_at': None,
+            'phone': None,
+            'avatar_url': None,
+            'email_verified': True,
+            'phone_verified': False,
+            'mfa_enabled': False,
+            'timezone': 'America/Toronto',
+            'locale': 'en-CA',
+            'deleted_at': None,
+            'created_at': datetime.now(timezone.utc),
+            'updated_at': datetime.now(timezone.utc),
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    return _make_user
+
+
+@pytest.fixture
+def make_auth_context(make_user):
+    def _make_auth_context(user=None, roles=None, permissions=None):
+        resolved_user = user or make_user()
+        return AuthContext(
+            user=resolved_user,
+            organization_id=resolved_user.organization_id,
+            roles=roles or ['lawyer'],
+            permissions=permissions or set(),
+        )
+
+    return _make_auth_context

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_frontend_origins_adds_localhost_aliases(monkeypatch):
+    monkeypatch.setenv('FRONTEND_ORIGIN', 'http://localhost:3000')
+    import app.core.config as config_module
+
+    importlib.reload(config_module)
+
+    assert config_module.settings.frontend_origins == [
+        'http://127.0.0.1:3000',
+        'http://localhost:3000',
+    ]
+
+
+def test_frontend_origins_supports_comma_delimited_values(monkeypatch):
+    monkeypatch.setenv('FRONTEND_ORIGIN', 'https://app.example.com, http://localhost:3000')
+    import app.core.config as config_module
+
+    importlib.reload(config_module)
+
+    assert 'https://app.example.com' in config_module.settings.frontend_origins
+    assert 'http://127.0.0.1:3000' in config_module.settings.frontend_origins

--- a/backend/tests/core/test_security.py
+++ b/backend/tests/core/test_security.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from app.core import security
+
+
+def test_hash_and_verify_password_round_trip():
+    stored = security.hash_password('password123')
+
+    assert stored != 'password123'
+    assert security.verify_password('password123', stored) is True
+    assert security.verify_password('wrong-password', stored) is False
+
+
+def test_hash_password_rejects_empty_input():
+    try:
+        security.hash_password('   ')
+    except ValueError as exc:
+        assert 'Password cannot be empty' in str(exc)
+    else:
+        raise AssertionError('Expected ValueError for empty password')
+
+
+def test_access_token_can_be_decoded():
+    token = security.create_access_token('user-1', 'org-1', ['lawyer'])
+    payload = security.decode_access_token(token)
+
+    assert payload['sub'] == 'user-1'
+    assert payload['org'] == 'org-1'
+    assert payload['roles'] == ['lawyer']
+    assert payload['type'] == 'access'
+
+
+def test_invitation_token_hash_is_deterministic():
+    token = security.generate_invitation_token()
+
+    assert security.hash_invitation_token(token) == security.hash_invitation_token(token)

--- a/backend/tests/db/test_deps.py
+++ b/backend/tests/db/test_deps.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from app.db import deps
+
+
+class DummySession:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_get_db_yields_and_closes_session(monkeypatch):
+    session = DummySession()
+    monkeypatch.setattr(deps, 'SessionLocal', lambda: session)
+
+    generator = deps.get_db()
+    yielded = next(generator)
+    assert yielded is session
+
+    try:
+        next(generator)
+    except StopIteration:
+        pass
+
+    assert session.closed is True

--- a/backend/tests/main/test_main.py
+++ b/backend/tests/main/test_main.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.main import app
+
+
+def test_main_app_has_cors_and_metadata():
+    assert app.title == 'VisaTrack API'
+    assert any(m.cls is CORSMiddleware for m in app.user_middleware)

--- a/backend/tests/models/test_models_smoke.py
+++ b/backend/tests/models/test_models_smoke.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from app.models.case import Case
+from app.models.case_client import CaseClient
+from app.models.milestone import Milestone
+from app.models.organization import Organization
+from app.models.role import Role
+from app.models.test import Test as TestModel
+from app.models.user import User
+from app.models.user_invitation import UserInvitation
+from app.models.user_profile import UserProfile
+from app.models.user_role import UserRole
+
+TestModel.__test__ = False
+
+
+def test_model_metadata_smoke():
+    assert Organization.__tablename__ == 'organizations'
+    assert User.__tablename__ == 'users'
+    assert Case.__tablename__ == 'cases'
+    assert Milestone.__tablename__ == 'milestones'
+    assert Role.__tablename__ == 'roles'
+    assert UserRole.__tablename__ == 'user_roles'
+    assert UserProfile.__tablename__ == 'user_profiles'
+    assert CaseClient.__tablename__ == 'case_clients'
+    assert UserInvitation.__tablename__ == 'user_invitations'
+    assert TestModel.__tablename__ == 'test'

--- a/backend/tests/schemas/test_schema_smoke.py
+++ b/backend/tests/schemas/test_schema_smoke.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.schemas.admin import AdminCreateOrganizationRequest
+from app.schemas.auth import LoginRequest
+from app.schemas.case import CaseDocumentUploadInitiateRequest
+from app.schemas.client import ClientCaseListItem
+from app.schemas.dashboard import DashboardStats
+from app.schemas.lawyer import LawyerClientCreateRequest
+from app.schemas.organization import OrganizationRead
+from app.schemas.user import UserRead
+
+
+def test_schema_objects_validate_expected_fields():
+    now = datetime.now(timezone.utc)
+    assert AdminCreateOrganizationRequest(name='Acme', contact_email='a@b.com').subscription_tier == 'basic'
+    assert LoginRequest(organization_slug='acme', email='user@example.com', password='secret').organization_slug == 'acme'
+    assert CaseDocumentUploadInitiateRequest(file_name='doc.pdf', file_type='application/pdf', file_size_bytes=10).file_type == 'application/pdf'
+    assert DashboardStats(organizations=1, users=2, active_cases=3, completed_cases=4).users == 2
+    assert LawyerClientCreateRequest(email='c@example.com', first_name='C', last_name='L').send_invite is True
+
+    org = OrganizationRead(id=uuid4(), name='Acme', slug='acme', contact_email='a@b.com', subscription_status='active', created_at=now)
+    user = UserRead(id=uuid4(), organization_id=None, email='user@example.com', first_name='Test', last_name='User', status='active', created_at=now)
+    client_case = ClientCaseListItem(id=uuid4(), case_number='C-1', case_type='Express Entry', status='intake', priority='medium', primary_lawyer_name=None, target_filing_date=None, created_at=now)
+
+    assert org.slug == 'acme'
+    assert user.email == 'user@example.com'
+    assert client_case.case_number == 'C-1'

--- a/backend/tests/services/test_audit.py
+++ b/backend/tests/services/test_audit.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.services.audit import log_activity, log_document_access
+
+
+def test_log_activity_executes_insert():
+    db = MagicMock()
+    organization_id = uuid4()
+    user_id = uuid4()
+
+    log_activity(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+        action='created',
+        entity_type='case',
+        entity_id=uuid4(),
+        new_values={'status': 'created'},
+    )
+
+    assert db.execute.call_count == 1
+    params = db.execute.call_args[0][1]
+    assert params['organization_id'] == str(organization_id)
+    assert params['user_id'] == str(user_id)
+    assert params['action'] == 'created'
+
+
+def test_log_document_access_executes_insert():
+    db = MagicMock()
+    document_id = uuid4()
+
+    log_document_access(
+        db,
+        document_id=document_id,
+        user_id=None,
+        action='download',
+        ip_address='127.0.0.1',
+        user_agent='pytest',
+    )
+
+    assert db.execute.call_count == 1
+    params = db.execute.call_args[0][1]
+    assert params['document_id'] == str(document_id)
+    assert params['action'] == 'download'
+    assert params['ip_address'] == '127.0.0.1'

--- a/backend/tests/services/test_rbac.py
+++ b/backend/tests/services/test_rbac.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services import rbac
+from tests.support import FakeResult, row
+
+
+def test_ensure_system_role_returns_existing_role():
+    existing = row(id=uuid4(), slug='lawyer')
+    db = MagicMock()
+    db.scalar.return_value = existing
+
+    result = rbac.ensure_system_role(db, 'lawyer')
+
+    assert result is existing
+    db.add.assert_not_called()
+
+
+def test_ensure_system_role_creates_missing_role():
+    db = MagicMock()
+    db.scalar.return_value = None
+
+    result = rbac.ensure_system_role(db, 'lawyer')
+
+    assert result.slug == 'lawyer'
+    assert result.is_system is True
+    db.add.assert_called_once()
+    db.flush.assert_called_once()
+
+
+def test_ensure_system_role_rejects_unknown_slug():
+    db = MagicMock()
+    db.scalar.return_value = None
+
+    with pytest.raises(ValueError):
+        rbac.ensure_system_role(db, 'mystery-role')
+
+
+def test_assign_role_to_user_is_noop_when_role_exists(monkeypatch):
+    db = MagicMock()
+    db.scalar.return_value = object()
+    role = row(id=uuid4())
+    monkeypatch.setattr(rbac, 'ensure_system_role', lambda db, role_slug: role)
+
+    rbac.assign_role_to_user(db, user_id=uuid4(), role_slug='lawyer', assigned_by=uuid4())
+
+    db.add.assert_not_called()
+
+
+def test_get_user_roles_normalizes_and_deduplicates():
+    db = MagicMock()
+    db.execute.return_value = FakeResult(['LAWYER', 'lawyer', 'client'])
+
+    result = rbac.get_user_roles(db, uuid4(), uuid4())
+
+    assert result == ['client', 'lawyer']

--- a/backend/tests/services/test_storage.py
+++ b/backend/tests/services/test_storage.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import NoCredentialsError
+
+from app.services import storage
+
+
+class DummyBody:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def test_create_presigned_upload_includes_kms_headers(monkeypatch):
+    client = MagicMock()
+    client.generate_presigned_url.return_value = 'https://example.com/upload'
+    monkeypatch.setattr(storage, '_s3_client', lambda: client)
+    monkeypatch.setattr(storage.settings, 'aws_kms_key_id', 'kms-key')
+    monkeypatch.setattr(storage.settings, 's3_presign_expires_seconds', 300)
+    monkeypatch.setattr(storage.settings, 's3_bucket_name', 'bucket-name')
+
+    result = storage.create_presigned_upload(object_key='docs/test.pdf', content_type='application/pdf')
+
+    assert result.url == 'https://example.com/upload'
+    assert result.headers['x-amz-server-side-encryption'] == 'aws:kms'
+    assert result.expires_in_seconds == 300
+
+
+def test_create_presigned_upload_surfaces_missing_credentials(monkeypatch):
+    client = MagicMock()
+    client.generate_presigned_url.side_effect = NoCredentialsError()
+    monkeypatch.setattr(storage, '_s3_client', lambda: client)
+    monkeypatch.setattr(storage.settings, 'aws_kms_key_id', '')
+
+    with pytest.raises(storage.StorageConfigurationError):
+        storage.create_presigned_upload(object_key='docs/test.pdf', content_type='application/pdf')
+
+
+def test_download_and_object_fetch_helpers(monkeypatch):
+    client = MagicMock()
+    client.generate_presigned_url.return_value = 'https://example.com/download'
+    client.head_object.return_value = {'ContentLength': 42}
+    client.get_object.return_value = {'Body': DummyBody(b'document-bytes')}
+    monkeypatch.setattr(storage, '_s3_client', lambda: client)
+    monkeypatch.setattr(storage.settings, 's3_bucket_name', 'bucket-name')
+
+    assert storage.create_presigned_download(object_key='docs/test.pdf') == 'https://example.com/download'
+    assert storage.head_object(object_key='docs/test.pdf')['ContentLength'] == 42
+    assert storage.get_object_bytes(object_key='docs/test.pdf') == b'document-bytes'

--- a/backend/tests/support.py
+++ b/backend/tests/support.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class FakeScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class FakeResult:
+    def __init__(self, rows=None, scalar_value=None):
+        self._rows = rows or []
+        self._scalar_value = scalar_value
+
+    def all(self):
+        return self._rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def one(self):
+        if len(self._rows) != 1:
+            raise AssertionError(f"Expected exactly one row, found {len(self._rows)}")
+        return self._rows[0]
+
+    def mappings(self):
+        return self
+
+    def scalars(self):
+        return FakeScalarResult(self._rows)
+
+    def scalar_one(self):
+        if self._scalar_value is not None:
+            return self._scalar_value
+        if not self._rows:
+            raise AssertionError('No rows available for scalar_one()')
+        return self._rows[0]
+
+
+def row(**values):
+    return SimpleNamespace(**values)


### PR DESCRIPTION
# Pull Request

## 📝 Description
Backend API coverage is in place.

What changed:

Added route tests so every implemented backend API handler has at least one test path:
[test_admin.py](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[test_auth.py](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[test_lawyer.py](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[test_cases.py](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
Extended the shared fake result helper used by route tests:
[support.py](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
CI is already set to run the backend suite explicitly:
[ci-build.yml (line 78)](https://file+.vscode-resource.vscode-cdn.net/Users/umerqamar/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
Coverage scope now includes:

auth: login, me, me/settings, settings update, change-password, accept-invitation
admin: overview, org list/create, role list, user list/create, assign role
lawyer: profile get/update, client list/create, case list/create, invite client
cases: create/list/get/update, milestone create/update/delete, message create, workspace, permissions update, custom suite/document create, rename/delete/status update, upload initiate/complete, download URL, download-all archive
previously covered route modules remain covered:
client, dashboard, health, organizations, users
Validation:

./backend/.venv/bin/pytest backend/tests -q
Result:

78 passed
## 🔗 Linked Issue
Closes #

## ✅ Checklist
- [ ] My code follows the project's style guidelines.
- [ ] I have linked the relevant issue using "Closes #X".
- [ ] I have requested exactly 1 reviewer.
- [ ] I have verified that the build passes locally.

## 📸 Screenshots (if applicable)
