### PR TITLE
Admin panel UX + role-scope hardening + org/user management improvements

### DIFF
--- a/backend/app/api/deps/auth.py
+++ b/backend/app/api/deps/auth.py
@@ -16,6 +16,7 @@ from app.db.deps import get_db
 from app.models.role import Role
 from app.models.user import User
 from app.models.user_role import UserRole
+from app.services.rbac import canonical_role_slug, select_default_active_role
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -25,6 +26,7 @@ class AuthContext:
     user: User
     organization_id: UUID
     roles: list[str]
+    active_role: str
     permissions: set[str]
 
     @property
@@ -53,6 +55,7 @@ def get_auth_context(
     user_id = payload.get("sub")
     org_id = payload.get("org")
     token_roles = payload.get("roles", [])
+    token_active_role = canonical_role_slug(str(payload.get("active_role") or ""))
 
     if not user_id or not org_id:
         raise _http_401("Malformed token")
@@ -81,23 +84,34 @@ def get_auth_context(
     ).all()
 
     normalized_roles = sorted(
-        {str(row.slug).lower() for row in db_role_rows} | {str(role).lower() for role in token_roles}
+        {canonical_role_slug(str(row.slug)) for row in db_role_rows}
+        | {canonical_role_slug(str(role)) for role in token_roles}
     )
+    active_role = token_active_role if token_active_role in normalized_roles else select_default_active_role(normalized_roles)
+    if active_role is None:
+        raise _http_401("No active role assigned")
 
-    permissions: set[str] = set()
+    role_permissions: dict[str, set[str]] = {}
     for row in db_role_rows:
+        role_slug = canonical_role_slug(str(row.slug))
+        role_permissions.setdefault(role_slug, set())
         for perm in (row.permissions or []):
-            permissions.add(str(perm).strip())
+            cleaned = str(perm).strip()
+            if cleaned:
+                role_permissions[role_slug].add(cleaned)
+
+    permissions = set(role_permissions.get(active_role, set()))
 
     # Backward compatible: if token roles include a super admin role but DB perms are missing,
     # treat it as full access (DB should still be source of truth).
-    if "super_admin" in normalized_roles:
+    if active_role == "super_admin" and "super_admin" in normalized_roles:
         permissions.add("*")
 
     return AuthContext(
         user=user,
         organization_id=user.organization_id,
         roles=normalized_roles,
+        active_role=active_role,
         permissions=permissions,
     )
 

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -13,11 +14,18 @@ from app.models.case import Case
 from app.models.organization import Organization
 from app.models.role import Role
 from app.models.user import User
+from app.models.user_invitation import UserInvitation
 from app.models.user_role import UserRole
 from app.schemas.admin import (
     AdminAssignRoleRequest,
+    AdminCaseAssignmentRequest,
+    AdminCaseAssignmentResponse,
     AdminCreateOrganizationRequest,
     AdminCreateUserRequest,
+    AdminOperationsResponse,
+    AdminOpsCaseItem,
+    AdminOpsInvitationItem,
+    AdminOpsLawyerWorkloadItem,
     AdminOverviewCase,
     AdminOverviewOrganization,
     AdminOverviewResponse,
@@ -28,7 +36,7 @@ from app.schemas.admin import (
 from app.schemas.organization import OrganizationRead
 from app.schemas.user import UserListItem
 from app.services.audit import log_activity
-from app.services.rbac import assign_role_to_user
+from app.services.rbac import assign_role_to_user, canonical_role_slug, revoke_role_from_user
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -47,7 +55,12 @@ def _normalize_email(value: str) -> str:
 
 
 def _is_super_admin(auth: AuthContext) -> bool:
-    return "super_admin" in auth.roles
+    return auth.active_role == "super_admin"
+
+
+def _require_active_super_admin(auth: AuthContext) -> None:
+    if not _is_super_admin(auth):
+        raise HTTPException(status_code=403, detail="Super admin role is required for this action")
 
 
 def _require_org_scope(auth: AuthContext, organization_id: UUID) -> None:
@@ -55,6 +68,44 @@ def _require_org_scope(auth: AuthContext, organization_id: UUID) -> None:
         return
     if auth.organization_id != organization_id:
         raise HTTPException(status_code=403, detail="Cross-organization access is not allowed")
+
+
+def _list_user_roles(
+    db: Session,
+    *,
+    user_ids: list[UUID],
+) -> dict[UUID, list[str]]:
+    if not user_ids:
+        return {}
+
+    now = datetime.now(timezone.utc)
+    rows = db.execute(
+        select(UserRole.user_id, Role.slug)
+        .join(Role, Role.id == UserRole.role_id)
+        .join(User, User.id == UserRole.user_id)
+        .where(
+            UserRole.user_id.in_(user_ids),
+            (UserRole.expires_at.is_(None) | (UserRole.expires_at > now)),
+            (Role.organization_id.is_(None) | (Role.organization_id == User.organization_id)),
+        )
+    ).all()
+
+    roles_by_user: dict[UUID, set[str]] = {user_id: set() for user_id in user_ids}
+    for row in rows:
+        roles_by_user.setdefault(row.user_id, set()).add(canonical_role_slug(str(row.slug)))
+
+    return {user_id: sorted(roles) for user_id, roles in roles_by_user.items()}
+
+
+def _is_active_case_status(value: str) -> bool:
+    return str(value).lower() not in {"approved", "refused", "withdrawn", "closed"}
+
+
+def _resolve_admin_org_scope(auth: AuthContext, organization_id: Optional[UUID]) -> UUID:
+    if not isinstance(organization_id, UUID):
+        return auth.organization_id
+    _require_org_scope(auth, organization_id)
+    return organization_id
 
 
 @router.get("/overview", response_model=AdminOverviewResponse)
@@ -192,10 +243,12 @@ def list_admin_organizations(
 @router.post("/organizations", response_model=OrganizationRead, status_code=status.HTTP_201_CREATED)
 def create_organization(
     payload: AdminCreateOrganizationRequest,
-    auth: AuthContext = Depends(require_permissions("*")),
+    auth: AuthContext = Depends(require_roles("super_admin")),
     db: Session = Depends(get_db),
 ) -> OrganizationRead:
-    slug = payload.slug.strip().lower() if payload.slug else _slugify(payload.name)
+    _require_active_super_admin(auth)
+
+    slug = _slugify(payload.slug)
     if not slug:
         raise HTTPException(status_code=400, detail="Invalid organization slug")
 
@@ -230,7 +283,284 @@ def create_organization(
 
     db.commit()
     db.refresh(new_org)
-    return OrganizationRead.model_validate(new_org)
+    return new_org
+
+
+@router.delete("/organizations/{organization_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_organization(
+    organization_id: UUID,
+    auth: AuthContext = Depends(require_roles("super_admin")),
+    db: Session = Depends(get_db),
+) -> None:
+    _require_active_super_admin(auth)
+
+    organization = db.scalar(
+        select(Organization).where(Organization.id == organization_id, Organization.deleted_at.is_(None))
+    )
+    if organization is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if organization.id == auth.organization_id:
+        raise HTTPException(status_code=400, detail="You cannot delete your active organization")
+
+    now = datetime.now(timezone.utc)
+    organization.deleted_at = now
+    db.add(organization)
+
+    log_activity(
+        db,
+        organization_id=organization.id,
+        user_id=auth.user_id,
+        action="deleted",
+        entity_type="organization",
+        entity_id=organization.id,
+        new_values={"name": organization.name, "slug": organization.slug},
+    )
+
+    db.commit()
+
+
+@router.get("/operations", response_model=AdminOperationsResponse)
+def get_admin_operations(
+    organization_id: Optional[UUID] = Query(default=None),
+    auth: AuthContext = Depends(require_roles("org_admin", "super_admin")),
+    db: Session = Depends(get_db),
+) -> AdminOperationsResponse:
+    scoped_org_id = _resolve_admin_org_scope(auth, organization_id)
+    now = datetime.now(timezone.utc)
+
+    primary_lawyer = aliased(User)
+    active_case_rows = db.execute(
+        select(
+            Case.id,
+            Case.case_number,
+            Case.case_type,
+            Case.status,
+            Case.priority,
+            Case.created_at,
+            Case.primary_lawyer_id,
+            primary_lawyer.first_name,
+            primary_lawyer.last_name,
+        )
+        .outerjoin(primary_lawyer, primary_lawyer.id == Case.primary_lawyer_id)
+        .where(
+            Case.organization_id == scoped_org_id,
+            Case.deleted_at.is_(None),
+        )
+        .order_by(Case.created_at.asc())
+    ).all()
+
+    active_case_items = []
+    for row in active_case_rows:
+        if not _is_active_case_status(row.status):
+            continue
+        days_open = max(0, (now - row.created_at).days)
+        lawyer_name = None
+        if row.first_name and row.last_name:
+            lawyer_name = f"{row.first_name} {row.last_name}"
+        active_case_items.append(
+            AdminOpsCaseItem(
+                case_id=row.id,
+                case_number=row.case_number,
+                case_type=row.case_type,
+                status=row.status,
+                priority=row.priority,
+                created_at=row.created_at,
+                days_open=days_open,
+                primary_lawyer_id=row.primary_lawyer_id,
+                primary_lawyer_name=lawyer_name,
+            )
+        )
+
+    unassigned_cases = sorted(
+        [item for item in active_case_items if item.primary_lawyer_id is None],
+        key=lambda item: item.created_at,
+    )[:20]
+    aging_cases = sorted(active_case_items, key=lambda item: item.days_open, reverse=True)[:20]
+
+    lawyer_rows = db.execute(
+        select(User.id, User.first_name, User.last_name)
+        .join(UserRole, UserRole.user_id == User.id)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(
+            User.organization_id == scoped_org_id,
+            User.deleted_at.is_(None),
+            cast(User.status, String) == "active",
+            cast(Role.slug, String) == "lawyer",
+            (UserRole.expires_at.is_(None) | (UserRole.expires_at > now)),
+            (Role.organization_id.is_(None) | (Role.organization_id == scoped_org_id)),
+        )
+        .distinct()
+        .order_by(User.first_name.asc(), User.last_name.asc())
+    ).all()
+    case_count_by_lawyer: dict[UUID, int] = {}
+    for item in active_case_items:
+        if item.primary_lawyer_id is None:
+            continue
+        case_count_by_lawyer[item.primary_lawyer_id] = case_count_by_lawyer.get(item.primary_lawyer_id, 0) + 1
+
+    lawyer_workload = [
+        AdminOpsLawyerWorkloadItem(
+            lawyer_user_id=row.id,
+            full_name=f"{row.first_name} {row.last_name}",
+            active_cases=case_count_by_lawyer.get(row.id, 0),
+        )
+        for row in lawyer_rows
+    ]
+
+    invited_by_user = aliased(User)
+    invitation_rows = db.execute(
+        select(
+            UserInvitation.id,
+            UserInvitation.user_id,
+            UserInvitation.email,
+            UserInvitation.role_slug,
+            UserInvitation.created_at,
+            UserInvitation.expires_at,
+            UserInvitation.accepted_at,
+            UserInvitation.revoked_at,
+            invited_by_user.first_name,
+            invited_by_user.last_name,
+        )
+        .outerjoin(invited_by_user, invited_by_user.id == UserInvitation.invited_by)
+        .where(UserInvitation.organization_id == scoped_org_id)
+        .order_by(UserInvitation.created_at.desc())
+        .limit(100)
+    ).all()
+
+    pending_invitations: list[AdminOpsInvitationItem] = []
+    for row in invitation_rows:
+        if row.accepted_at is not None:
+            status_value = "accepted"
+        elif row.revoked_at is not None:
+            status_value = "revoked"
+        elif row.expires_at < now:
+            status_value = "expired"
+        else:
+            status_value = "pending"
+
+        if status_value != "pending":
+            continue
+
+        invited_by_name = None
+        if row.first_name and row.last_name:
+            invited_by_name = f"{row.first_name} {row.last_name}"
+
+        pending_invitations.append(
+            AdminOpsInvitationItem(
+                invitation_id=row.id,
+                user_id=row.user_id,
+                email=row.email,
+                role_slug=row.role_slug,
+                created_at=row.created_at,
+                expires_at=row.expires_at,
+                status=status_value,
+                invited_by_name=invited_by_name,
+            )
+        )
+
+    return AdminOperationsResponse(
+        organization_id=scoped_org_id,
+        unassigned_cases=unassigned_cases,
+        aging_cases=aging_cases,
+        lawyer_workload=lawyer_workload,
+        pending_invitations=pending_invitations,
+    )
+
+
+@router.post("/cases/{case_number}/assign", response_model=AdminCaseAssignmentResponse)
+def assign_case_lawyer(
+    case_number: str,
+    payload: AdminCaseAssignmentRequest,
+    auth: AuthContext = Depends(require_roles("org_admin", "super_admin")),
+    db: Session = Depends(get_db),
+) -> AdminCaseAssignmentResponse:
+    case_stmt = select(Case).where(Case.case_number == case_number, Case.deleted_at.is_(None))
+    if not _is_super_admin(auth):
+        case_stmt = case_stmt.where(Case.organization_id == auth.organization_id)
+
+    case = db.scalar(case_stmt)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Case not found")
+
+    _require_org_scope(auth, case.organization_id)
+
+    assigned_lawyer_name: Optional[str] = None
+    if payload.lawyer_user_id is not None:
+        now = datetime.now(timezone.utc)
+        lawyer = db.scalar(
+            select(User)
+            .join(UserRole, UserRole.user_id == User.id)
+            .join(Role, Role.id == UserRole.role_id)
+            .where(
+                User.id == payload.lawyer_user_id,
+                User.organization_id == case.organization_id,
+                User.deleted_at.is_(None),
+                cast(User.status, String) == "active",
+                cast(Role.slug, String) == "lawyer",
+                (UserRole.expires_at.is_(None) | (UserRole.expires_at > now)),
+                (Role.organization_id.is_(None) | (Role.organization_id == case.organization_id)),
+            )
+        )
+        if lawyer is None:
+            raise HTTPException(status_code=400, detail="Selected user is not an active lawyer in this organization")
+        case.primary_lawyer_id = lawyer.id
+        assigned_lawyer_name = f"{lawyer.first_name} {lawyer.last_name}"
+    else:
+        case.primary_lawyer_id = None
+
+    db.add(case)
+    log_activity(
+        db,
+        organization_id=case.organization_id,
+        user_id=auth.user_id,
+        action="assigned",
+        entity_type="case",
+        entity_id=case.id,
+        new_values={
+            "case_number": case.case_number,
+            "primary_lawyer_id": str(case.primary_lawyer_id) if case.primary_lawyer_id else None,
+        },
+    )
+    db.commit()
+
+    return AdminCaseAssignmentResponse(
+        case_id=case.id,
+        case_number=case.case_number,
+        primary_lawyer_id=case.primary_lawyer_id,
+        primary_lawyer_name=assigned_lawyer_name,
+    )
+
+
+@router.post("/invitations/{invitation_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
+def revoke_invitation(
+    invitation_id: UUID,
+    auth: AuthContext = Depends(require_roles("org_admin", "super_admin")),
+    db: Session = Depends(get_db),
+) -> None:
+    invitation = db.scalar(select(UserInvitation).where(UserInvitation.id == invitation_id))
+    if invitation is None:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+
+    _require_org_scope(auth, invitation.organization_id)
+
+    if invitation.accepted_at is not None:
+        raise HTTPException(status_code=400, detail="Accepted invitation cannot be revoked")
+    if invitation.revoked_at is not None:
+        return
+
+    invitation.revoked_at = datetime.now(timezone.utc)
+    db.add(invitation)
+    log_activity(
+        db,
+        organization_id=invitation.organization_id,
+        user_id=auth.user_id,
+        action="revoked",
+        entity_type="invitation",
+        entity_id=invitation.id,
+        new_values={"email": invitation.email, "role_slug": invitation.role_slug},
+    )
+    db.commit()
 
 
 @router.get("/roles", response_model=list[AdminRoleItem])
@@ -264,7 +594,7 @@ def list_admin_users(
 ) -> list[UserListItem]:
     stmt = select(User).where(User.deleted_at.is_(None)).order_by(User.created_at.desc())
 
-    requested_org_id = organization_id if organization_id is not None else auth.organization_id
+    requested_org_id = organization_id if isinstance(organization_id, UUID) else auth.organization_id
     if _is_super_admin(auth):
         if organization_id is not None:
             stmt = stmt.where(User.organization_id == organization_id)
@@ -273,6 +603,10 @@ def list_admin_users(
         stmt = stmt.where(User.organization_id == auth.organization_id)
 
     users = db.scalars(stmt.limit(limit).offset(offset)).all()
+    roles_by_user = _list_user_roles(
+        db,
+        user_ids=[user.id for user in users],
+    )
     return [
         UserListItem(
             id=user.id,
@@ -281,6 +615,7 @@ def list_admin_users(
             status=user.status,
             organization_id=user.organization_id,
             created_at=user.created_at,
+            roles=roles_by_user.get(user.id, []),
         )
         for user in users
     ]
@@ -357,7 +692,42 @@ def create_user(
         status=new_user.status,
         organization_id=new_user.organization_id,
         created_at=new_user.created_at,
+        roles=[payload.role_slug.strip().lower()],
     )
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: UUID,
+    auth: AuthContext = Depends(require_permissions("users:manage")),
+    db: Session = Depends(get_db),
+) -> None:
+    user = db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    _require_org_scope(auth, user.organization_id)
+
+    if user.id == auth.user_id:
+        raise HTTPException(status_code=400, detail="You cannot delete your own account")
+
+    now = datetime.now(timezone.utc)
+    user.deleted_at = now
+    user.status = "disabled"
+    user.updated_at = now
+    db.add(user)
+
+    log_activity(
+        db,
+        organization_id=user.organization_id,
+        user_id=auth.user_id,
+        action="deleted",
+        entity_type="user",
+        entity_id=user.id,
+        new_values={"email": user.email},
+    )
+
+    db.commit()
 
 
 @router.post("/users/{user_id}/roles", status_code=status.HTTP_204_NO_CONTENT)
@@ -388,6 +758,44 @@ def assign_user_role(
         entity_type="role",
         entity_id=user.id,
         new_values={"role_slug": payload.role_slug.strip().lower()},
+    )
+
+    db.commit()
+
+
+@router.delete("/users/{user_id}/roles/{role_slug}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_user_role(
+    user_id: UUID,
+    role_slug: str,
+    auth: AuthContext = Depends(require_permissions("users:manage", "roles:manage")),
+    db: Session = Depends(get_db),
+) -> None:
+    user = db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    _require_org_scope(auth, user.organization_id)
+
+    normalized_role = role_slug.strip().lower()
+    if user.id == auth.user_id and normalized_role in {"org_admin", "super_admin"}:
+        raise HTTPException(status_code=400, detail="You cannot remove your own admin role")
+
+    removed = revoke_role_from_user(
+        db,
+        user_id=user.id,
+        role_slug=normalized_role,
+    )
+    if not removed:
+        raise HTTPException(status_code=404, detail="Role assignment not found")
+
+    log_activity(
+        db,
+        organization_id=user.organization_id,
+        user_id=auth.user_id,
+        action="removed",
+        entity_type="role",
+        entity_id=user.id,
+        new_values={"role_slug": normalized_role},
     )
 
     db.commit()

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -29,9 +29,12 @@ from app.schemas.auth import (
     CurrentUserResponse,
     CurrentUserSettingsResponse,
     LoginRequest,
+    SwitchActiveRoleRequest,
+    SwitchActiveRoleResponse,
     UpdateCurrentUserSettingsRequest,
 )
 from app.services.audit import log_activity
+from app.services.rbac import canonical_role_slug, select_default_active_role
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -134,7 +137,11 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> AuthTokenResp
     if user.status.lower() == "invited":
         raise HTTPException(status_code=403, detail="Invitation pending acceptance")
 
-    token = create_access_token(str(user.id), str(organization.id), roles)
+    active_role = select_default_active_role(roles)
+    if active_role is None:
+        raise HTTPException(status_code=403, detail="No active role assigned. Contact admin")
+
+    token = create_access_token(str(user.id), str(organization.id), roles, active_role)
 
     user.login_attempts = 0
     user.locked_until = None
@@ -158,8 +165,32 @@ def me(auth: AuthContext = Depends(get_auth_context), db: Session = Depends(get_
         full_name=f"{auth.user.first_name} {auth.user.last_name}",
         status=auth.user.status,
         roles=auth.roles,
+        active_role=auth.active_role,
         onboarding_required=onboarding_required,
         last_login_at=auth.user.last_login_at,
+    )
+
+
+@router.post("/switch-role", response_model=SwitchActiveRoleResponse)
+def switch_active_role(
+    payload: SwitchActiveRoleRequest,
+    auth: AuthContext = Depends(get_auth_context),
+) -> SwitchActiveRoleResponse:
+    requested_role = canonical_role_slug(payload.role)
+    if requested_role not in auth.roles:
+        raise HTTPException(status_code=403, detail="Requested role is not assigned to this user")
+
+    token = create_access_token(
+        str(auth.user_id),
+        str(auth.organization_id),
+        auth.roles,
+        requested_role,
+    )
+    return SwitchActiveRoleResponse(
+        access_token=token,
+        expires_in_seconds=settings.auth_access_token_minutes * 60,
+        active_role=requested_role,
+        roles=auth.roles,
     )
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -95,7 +95,12 @@ def verify_password(password: str, stored_hash: str) -> bool:
     return hmac.compare_digest(candidate, stored_hash)
 
 
-def create_access_token(user_id: str, organization_id: str, roles: list[str]) -> str:
+def create_access_token(
+    user_id: str,
+    organization_id: str,
+    roles: list[str],
+    active_role: str | None = None,
+) -> str:
     now = datetime.now(timezone.utc)
     expires_at = now + timedelta(minutes=settings.auth_access_token_minutes)
     payload: dict[str, Any] = {
@@ -106,6 +111,8 @@ def create_access_token(user_id: str, organization_id: str, roles: list[str]) ->
         "exp": int(expires_at.timestamp()),
         "type": "access",
     }
+    if active_role:
+        payload["active_role"] = active_role
     return jwt.encode(payload, settings.auth_secret_key, algorithm=settings.auth_algorithm)
 
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class AdminCreateOrganizationRequest(BaseModel):
     name: str = Field(min_length=2, max_length=255)
     contact_email: str = Field(min_length=3, max_length=255)
-    slug: Optional[str] = Field(default=None, min_length=2, max_length=100)
+    slug: str = Field(min_length=2, max_length=100)
     subscription_tier: str = Field(default="basic", min_length=2, max_length=50)
     subscription_status: str = Field(default="active", min_length=2, max_length=50)
 
@@ -78,3 +78,51 @@ class AdminRoleItem(BaseModel):
 
 class AdminAssignRoleRequest(BaseModel):
     role_slug: str = Field(min_length=2, max_length=100)
+
+
+class AdminCaseAssignmentRequest(BaseModel):
+    lawyer_user_id: Optional[UUID] = None
+
+
+class AdminCaseAssignmentResponse(BaseModel):
+    case_id: UUID
+    case_number: str
+    primary_lawyer_id: Optional[UUID]
+    primary_lawyer_name: Optional[str]
+
+
+class AdminOpsLawyerWorkloadItem(BaseModel):
+    lawyer_user_id: UUID
+    full_name: str
+    active_cases: int
+
+
+class AdminOpsCaseItem(BaseModel):
+    case_id: UUID
+    case_number: str
+    case_type: str
+    status: str
+    priority: str
+    created_at: datetime
+    days_open: int
+    primary_lawyer_id: Optional[UUID]
+    primary_lawyer_name: Optional[str]
+
+
+class AdminOpsInvitationItem(BaseModel):
+    invitation_id: UUID
+    user_id: UUID
+    email: str
+    role_slug: str
+    created_at: datetime
+    expires_at: datetime
+    status: str
+    invited_by_name: Optional[str]
+
+
+class AdminOperationsResponse(BaseModel):
+    organization_id: UUID
+    unassigned_cases: list[AdminOpsCaseItem]
+    aging_cases: list[AdminOpsCaseItem]
+    lawyer_workload: list[AdminOpsLawyerWorkloadItem]
+    pending_invitations: list[AdminOpsInvitationItem]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -24,8 +24,21 @@ class CurrentUserResponse(BaseModel):
     full_name: str
     status: str
     roles: list[str]
+    active_role: str
     onboarding_required: bool
     last_login_at: Optional[datetime]
+
+
+class SwitchActiveRoleRequest(BaseModel):
+    role: str = Field(min_length=2, max_length=100)
+
+
+class SwitchActiveRoleResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in_seconds: int
+    active_role: str
+    roles: list[str]
 
 
 class CurrentUserSettingsResponse(BaseModel):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UserRead(BaseModel):
@@ -24,3 +24,4 @@ class UserListItem(BaseModel):
     status: str
     organization_id: Optional[UUID]
     created_at: datetime
+    roles: list[str] = Field(default_factory=list)

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -64,9 +64,25 @@ SYSTEM_ROLE_DEFINITIONS: dict[str, tuple[str, list[str]]] = {
     ),
 }
 
+ROLE_SLUG_ALIASES: dict[str, str] = {
+    "admin": "org_admin",
+}
+
+
+def canonical_role_slug(value: str) -> str:
+    normalized = value.strip().lower()
+    return ROLE_SLUG_ALIASES.get(normalized, normalized)
+
+ROLE_SWITCH_PRIORITY: tuple[str, ...] = (
+    "lawyer",
+    "org_admin",
+    "super_admin",
+    "client",
+)
+
 
 def ensure_system_role(db: Session, slug: str) -> Role:
-    normalized_slug = slug.strip().lower()
+    normalized_slug = canonical_role_slug(slug)
     role = db.scalar(
         select(Role).where(
             cast(Role.slug, String) == normalized_slug,
@@ -128,3 +144,31 @@ def get_user_roles(db: Session, user_id: UUID, organization_id: UUID) -> list[st
         )
     ).scalars().all()
     return sorted({str(row).lower() for row in rows})
+
+
+def select_default_active_role(roles: list[str]) -> str | None:
+    normalized = {canonical_role_slug(str(role)) for role in roles if str(role).strip()}
+    for role in ROLE_SWITCH_PRIORITY:
+        if role in normalized:
+            return role
+    if not normalized:
+        return None
+    return sorted(normalized)[0]
+
+
+def revoke_role_from_user(
+    db: Session,
+    *,
+    user_id: UUID,
+    role_slug: str,
+) -> bool:
+    role = ensure_system_role(db, role_slug)
+    existing = db.scalar(
+        select(UserRole).where(UserRole.user_id == user_id, UserRole.role_id == role.id)
+    )
+    if existing is None:
+        return False
+
+    db.delete(existing)
+    db.flush()
+    return True

--- a/backend/tests/api/routes/test_admin.py
+++ b/backend/tests/api/routes/test_admin.py
@@ -8,7 +8,12 @@ import pytest
 from fastapi import HTTPException
 
 from app.api.routes import admin
-from app.schemas.admin import AdminAssignRoleRequest, AdminCreateUserRequest
+from app.schemas.admin import (
+    AdminAssignRoleRequest,
+    AdminCaseAssignmentRequest,
+    AdminCreateOrganizationRequest,
+    AdminCreateUserRequest,
+)
 from tests.support import FakeResult, row
 
 
@@ -43,12 +48,36 @@ def test_create_organization_rejects_duplicate_slug(make_auth_context):
     auth = make_auth_context(roles=['super_admin'], permissions={'*'})
     db = MagicMock()
     db.scalar.return_value = uuid4()
-    payload = row(name='Acme', contact_email='hello@acme.com', slug='acme', subscription_tier='basic', subscription_status='active')
+    payload = AdminCreateOrganizationRequest(
+        name='Acme',
+        contact_email='hello@acme.com',
+        slug='acme',
+        subscription_tier='basic',
+        subscription_status='active',
+    )
 
     with pytest.raises(HTTPException) as exc:
         admin.create_organization(payload=payload, auth=auth, db=db)
 
     assert exc.value.status_code == 409
+
+
+def test_create_organization_requires_active_super_admin(make_auth_context):
+    auth = make_auth_context(roles=['super_admin', 'org_admin'], permissions={'*'})
+    auth.active_role = 'org_admin'
+    db = MagicMock()
+    payload = AdminCreateOrganizationRequest(
+        name='Acme',
+        contact_email='hello@acme.com',
+        slug='acme',
+        subscription_tier='basic',
+        subscription_status='active',
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        admin.create_organization(payload=payload, auth=auth, db=db)
+
+    assert exc.value.status_code == 403
 
 
 def test_list_admin_organizations_returns_scoped_rows(make_auth_context):
@@ -141,6 +170,7 @@ def test_create_user_assigns_role_and_returns_item(monkeypatch, make_auth_contex
     assert result.email == 'client@example.com'
     assert result.full_name == 'Client User'
     assert assigned[0][1] == 'client'
+    assert result.roles == ['client']
 
 
 def test_assign_user_role_assigns_and_commits(monkeypatch, make_auth_context, make_user):
@@ -165,4 +195,153 @@ def test_assign_user_role_assigns_and_commits(monkeypatch, make_auth_context, ma
     )
 
     assert assigned == [(existing_user.id, 'lawyer', auth.user_id)]
+    db.commit.assert_called_once()
+
+
+def test_list_admin_users_includes_roles(make_auth_context, make_user):
+    auth = make_auth_context(roles=['org_admin'], permissions={'users:manage'})
+    existing_user = make_user(organization_id=auth.organization_id)
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = [existing_user]
+    db.execute.return_value = FakeResult([row(user_id=existing_user.id, slug='lawyer')])
+
+    result = admin.list_admin_users(limit=25, offset=0, auth=auth, db=db)
+
+    assert result[0].roles == ['lawyer']
+
+
+def test_remove_user_role_revokes_and_commits(monkeypatch, make_auth_context, make_user):
+    auth = make_auth_context(roles=['org_admin'], permissions={'users:manage', 'roles:manage'})
+    existing_user = make_user(organization_id=auth.organization_id)
+    db = MagicMock()
+    db.scalar.return_value = existing_user
+
+    monkeypatch.setattr(admin, 'revoke_role_from_user', lambda db, user_id, role_slug: True)
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    admin.remove_user_role(user_id=existing_user.id, role_slug='lawyer', auth=auth, db=db)
+
+    db.commit.assert_called_once()
+
+
+def test_get_admin_operations_returns_snapshot(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    now = datetime.now(timezone.utc)
+    db = MagicMock()
+
+    db.execute.side_effect = [
+        FakeResult(
+            [
+                row(
+                    id=uuid4(),
+                    case_number='C-2026-001',
+                    case_type='H1B',
+                    status='intake',
+                    priority='high',
+                    created_at=now,
+                    primary_lawyer_id=None,
+                    first_name=None,
+                    last_name=None,
+                )
+            ]
+        ),
+        FakeResult([row(id=uuid4(), first_name='Avery', last_name='Law')]),
+        FakeResult(
+            [
+                row(
+                    id=uuid4(),
+                    user_id=uuid4(),
+                    email='invite@example.com',
+                    role_slug='client',
+                    created_at=now,
+                    expires_at=now,
+                    accepted_at=None,
+                    revoked_at=None,
+                    first_name='Admin',
+                    last_name='User',
+                )
+            ]
+        ),
+    ]
+
+    result = admin.get_admin_operations(auth=auth, db=db)
+
+    assert result.organization_id == auth.organization_id
+    assert len(result.unassigned_cases) == 1
+    assert len(result.lawyer_workload) == 1
+
+
+def test_assign_case_lawyer_updates_primary(monkeypatch, make_auth_context, make_user):
+    auth = make_auth_context(roles=['org_admin'])
+    existing_case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_number='C-2026-002',
+        primary_lawyer_id=None,
+    )
+    lawyer = make_user(organization_id=auth.organization_id)
+    db = MagicMock()
+    db.scalar.side_effect = [existing_case, lawyer]
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    result = admin.assign_case_lawyer(
+        case_number='C-2026-002',
+        payload=AdminCaseAssignmentRequest(lawyer_user_id=lawyer.id),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.primary_lawyer_id == lawyer.id
+    db.commit.assert_called_once()
+
+
+def test_revoke_invitation_marks_revoked(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['org_admin'])
+    invitation = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        accepted_at=None,
+        revoked_at=None,
+        email='invite@example.com',
+        role_slug='client',
+    )
+    db = MagicMock()
+    db.scalar.return_value = invitation
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    admin.revoke_invitation(invitation_id=invitation.id, auth=auth, db=db)
+
+    assert invitation.revoked_at is not None
+    db.commit.assert_called_once()
+
+
+def test_delete_user_soft_deletes_user(monkeypatch, make_auth_context, make_user):
+    auth = make_auth_context(roles=['org_admin'], permissions={'users:manage'})
+    target_user = make_user(organization_id=auth.organization_id)
+    db = MagicMock()
+    db.scalar.return_value = target_user
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    admin.delete_user(user_id=target_user.id, auth=auth, db=db)
+
+    assert target_user.deleted_at is not None
+    assert target_user.status == 'disabled'
+    db.commit.assert_called_once()
+
+
+def test_delete_organization_soft_deletes_org(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['super_admin'])
+    db = MagicMock()
+    organization = row(
+        id=uuid4(),
+        name='Org',
+        slug='org',
+        deleted_at=None,
+    )
+    db.scalar.return_value = organization
+    monkeypatch.setattr(admin, 'log_activity', lambda *args, **kwargs: None)
+
+    admin.delete_organization(organization_id=organization.id, auth=auth, db=db)
+
+    assert organization.deleted_at is not None
     db.commit.assert_called_once()

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -56,6 +56,7 @@ def test_me_returns_current_user_payload(monkeypatch, make_auth_context):
     result = auth.me(auth=auth_context, db=db)
 
     assert result.email == auth_context.user.email
+    assert result.active_role == 'lawyer'
     assert result.onboarding_required is True
 
 
@@ -78,7 +79,7 @@ def test_login_success_returns_access_token(monkeypatch, make_user):
     db.scalar.side_effect = [organization, user]
     db.execute.return_value = FakeResult(rows=['lawyer'])
     monkeypatch.setattr(auth, 'verify_password', lambda password, stored_hash: True)
-    monkeypatch.setattr(auth, 'create_access_token', lambda user_id, org_id, roles: 'token-123')
+    monkeypatch.setattr(auth, 'create_access_token', lambda user_id, org_id, roles, active_role=None: 'token-123')
 
     result = auth.login(
         payload=LoginRequest(organization_slug='acme', email='user@example.com', password='secret'),
@@ -88,6 +89,26 @@ def test_login_success_returns_access_token(monkeypatch, make_user):
     assert result.access_token == 'token-123'
     assert user.login_attempts == 0
     db.commit.assert_called_once()
+
+
+def test_switch_active_role_reissues_token(monkeypatch, make_auth_context):
+    auth_context = make_auth_context(roles=['lawyer', 'org_admin'])
+    captured = {}
+
+    def fake_create_access_token(user_id, org_id, roles, active_role=None):
+        captured['user_id'] = user_id
+        captured['org_id'] = org_id
+        captured['roles'] = roles
+        captured['active_role'] = active_role
+        return 'token-role-switch'
+
+    monkeypatch.setattr(auth, 'create_access_token', fake_create_access_token)
+
+    result = auth.switch_active_role(payload=row(role='org_admin'), auth=auth_context)
+
+    assert result.access_token == 'token-role-switch'
+    assert result.active_role == 'org_admin'
+    assert captured['active_role'] == 'org_admin'
 
 
 def test_me_settings_returns_current_user_settings(make_auth_context):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -54,6 +54,7 @@ def make_auth_context(make_user):
             user=resolved_user,
             organization_id=resolved_user.organization_id,
             roles=roles or ['lawyer'],
+            active_role=(roles or ['lawyer'])[0],
             permissions=permissions or set(),
         )
 

--- a/backend/tests/schemas/test_schema_smoke.py
+++ b/backend/tests/schemas/test_schema_smoke.py
@@ -15,7 +15,7 @@ from app.schemas.user import UserRead
 
 def test_schema_objects_validate_expected_fields():
     now = datetime.now(timezone.utc)
-    assert AdminCreateOrganizationRequest(name='Acme', contact_email='a@b.com').subscription_tier == 'basic'
+    assert AdminCreateOrganizationRequest(name='Acme', contact_email='a@b.com', slug='acme').subscription_tier == 'basic'
     assert LoginRequest(organization_slug='acme', email='user@example.com', password='secret').organization_slug == 'acme'
     assert CaseDocumentUploadInitiateRequest(file_name='doc.pdf', file_type='application/pdf', file_size_bytes=10).file_type == 'application/pdf'
     assert DashboardStats(organizations=1, users=2, active_cases=3, completed_cases=4).users == 2

--- a/frontend/figma/App.tsx
+++ b/frontend/figma/App.tsx
@@ -1,6 +1,8 @@
 import {
+  Briefcase,
   FileText,
   Settings,
+  Shield,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -18,6 +20,7 @@ import {
   getLawyerClients,
   login,
   logout,
+  switchActiveRole,
   updateCurrentUserSettings,
 } from '@/lib/api';
 
@@ -37,15 +40,15 @@ function getDefaultViewForUser(user: CurrentUser | null): AppView {
     return 'login';
   }
 
-  if (user.roles.includes('org_admin') || user.roles.includes('super_admin')) {
+  if (user.active_role === 'org_admin' || user.active_role === 'admin' || user.active_role === 'super_admin') {
     return 'admin';
   }
 
-  if (user.roles.includes('lawyer')) {
+  if (user.active_role === 'lawyer') {
     return 'lawyer';
   }
 
-  if (user.roles.includes('client')) {
+  if (user.active_role === 'client') {
     return 'client';
   }
 
@@ -61,9 +64,10 @@ function canAccessView(user: CurrentUser | null, view: AppView): boolean {
     return false;
   }
 
-  const isAdmin = user.roles.includes('org_admin') || user.roles.includes('super_admin');
-  const isLawyer = user.roles.includes('lawyer');
-  const isClient = user.roles.includes('client');
+  const isAdmin =
+    user.active_role === 'org_admin' || user.active_role === 'admin' || user.active_role === 'super_admin';
+  const isLawyer = user.active_role === 'lawyer';
+  const isClient = user.active_role === 'client';
 
   if (view === 'admin') {
     return isAdmin;
@@ -95,6 +99,7 @@ export default function App() {
   const [loadingProfileSettings, setLoadingProfileSettings] = useState(false);
   const [savingProfileSettings, setSavingProfileSettings] = useState(false);
   const [profileSettingsError, setProfileSettingsError] = useState<string | null>(null);
+  const [switchingRole, setSwitchingRole] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -260,6 +265,58 @@ export default function App() {
       });
   };
 
+  const handleSwitchRole = async (nextRole: string) => {
+    if (!currentUser || nextRole === currentUser.active_role || switchingRole) {
+      return;
+    }
+
+    setSwitchingRole(true);
+    try {
+      await switchActiveRole(nextRole);
+      const updatedUser = await getCurrentUser();
+      setCurrentUser(updatedUser);
+      setCurrentView(getDefaultViewForUser(updatedUser));
+      setSelectedCaseId(null);
+      setNewCaseError(null);
+    } catch {
+      handleLogout();
+    } finally {
+      setSwitchingRole(false);
+    }
+  };
+
+  const roleDisplayName = (role: string): string => {
+    if (role === 'super_admin') {
+      return 'Super Admin';
+    }
+    if (role === 'org_admin') {
+      return 'Admin';
+    }
+    if (role === 'admin') {
+      return 'Admin';
+    }
+    if (role === 'lawyer') {
+      return 'Lawyer';
+    }
+    if (role === 'client') {
+      return 'Client';
+    }
+    return role;
+  };
+
+  const sortedUserRoles = currentUser
+    ? [...currentUser.roles].sort((a, b) => {
+        const order: Record<string, number> = {
+          super_admin: 0,
+          org_admin: 1,
+          admin: 1,
+          lawyer: 2,
+          client: 3,
+        };
+        return (order[a] ?? 99) - (order[b] ?? 99);
+      })
+    : [];
+
   const handleCloseProfileDialog = () => {
     if (savingProfileSettings) {
       return;
@@ -300,6 +357,41 @@ export default function App() {
           <div className="flex items-center gap-3">
             {currentUser ? (
               <div className="flex items-center gap-2">
+                {currentUser.roles.length > 1 ? (
+                  <div className="flex items-center gap-2 border border-gray-700 bg-gray-900/70 rounded-xl px-2 py-1.5">
+                    <div className="flex items-center justify-center w-6 h-6 rounded-lg bg-gray-800 border border-gray-700">
+                      {currentUser.active_role === 'org_admin' || currentUser.active_role === 'admin' || currentUser.active_role === 'super_admin' ? (
+                        <Shield className="w-3.5 h-3.5 text-gray-200" />
+                      ) : (
+                        <Briefcase className="w-3.5 h-3.5 text-gray-200" />
+                      )}
+                    </div>
+                    <div className="leading-tight">
+                      <div className="inline-flex rounded-lg border border-gray-700 bg-gray-800 p-0.5">
+                        {sortedUserRoles.map((role) => {
+                          const isActive = role === currentUser.active_role;
+                          return (
+                            <button
+                              key={role}
+                              type="button"
+                              disabled={switchingRole || isActive}
+                              onClick={() => {
+                                void handleSwitchRole(role);
+                              }}
+                              className={`px-2 py-1 text-[11px] rounded-md transition-colors ${
+                                isActive
+                                  ? 'bg-white text-gray-900 font-semibold'
+                                  : 'text-gray-300 hover:text-white hover:bg-gray-700'
+                              }`}
+                            >
+                              {roleDisplayName(role)}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
                 <button
                   onClick={handleOpenProfileDialog}
                   className="text-xs border border-gray-700 hover:border-gray-500 px-3 py-2 rounded-lg flex items-center gap-1"
@@ -346,9 +438,6 @@ export default function App() {
           onViewActiveCases={handleViewActiveCases}
           onSelectCase={handleSelectCase}
           onCreateCase={handleOpenNewCaseDialog}
-          onAddClient={handleOpenNewCaseDialog}
-          onViewMessages={handleViewActiveCases}
-          onScheduleAppointment={handleViewActiveCases}
           lawyerName={currentUser?.full_name}
         />
       ) : null}
@@ -375,7 +464,7 @@ export default function App() {
       ) : null}
 
       {currentView === 'client' ? <ClientDashboard /> : null}
-      {currentView === 'admin' ? <AdminDashboard /> : null}
+      {currentView === 'admin' ? <AdminDashboard currentUser={currentUser} /> : null}
       {isNewCaseDialogOpen &&
       (currentView === 'lawyer' || currentView === 'active-cases' || currentView === 'case-config') ? (
         <NewCaseDialog

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -1,19 +1,26 @@
-import { Briefcase, Building2, CheckCircle2, RefreshCw, Shield, Users } from 'lucide-react';
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { RefreshCw, Shield } from 'lucide-react';
+import { FormEvent, useEffect, useState } from 'react';
 
 import {
+  assignAdminRole,
+  assignAdminCaseLawyer,
   type AdminCreateOrganizationInput,
+  type AdminOperations,
   type AdminRoleItem,
   type AdminCreateUserInput,
-  type AdminOverview,
+  type CurrentUser,
   type OrganizationListItem,
   type UserListItem,
   createAdminOrganization,
   createAdminUser,
+  deleteAdminOrganization,
+  deleteAdminUser,
   getAdminOrganizations,
-  getAdminOverview,
+  getAdminOperations,
   getAdminRoles,
   getAdminUsers,
+  removeAdminRole,
+  revokeAdminInvitation,
 } from '@/lib/api';
 
 function formatDate(value: string): string {
@@ -47,19 +54,32 @@ const initialUserForm: AdminCreateUserInput = {
   role_slug: 'lawyer',
 };
 
-export function AdminDashboard() {
+type AdminDashboardProps = {
+  currentUser: CurrentUser | null;
+};
+
+export function AdminDashboard({ currentUser }: AdminDashboardProps) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [flash, setFlash] = useState<FlashState>(null);
 
-  const [overview, setOverview] = useState<AdminOverview | null>(null);
+  const [operations, setOperations] = useState<AdminOperations | null>(null);
   const [organizations, setOrganizations] = useState<OrganizationListItem[]>([]);
   const [users, setUsers] = useState<UserListItem[]>([]);
   const [roles, setRoles] = useState<AdminRoleItem[]>([]);
 
   const [orgForm, setOrgForm] = useState(initialOrgForm);
   const [userForm, setUserForm] = useState(initialUserForm);
+  const [roleDraftByUserId, setRoleDraftByUserId] = useState<Record<string, string>>({});
+  const [busyRoleUserId, setBusyRoleUserId] = useState<string | null>(null);
+  const [caseAssignmentDraft, setCaseAssignmentDraft] = useState<Record<string, string>>({});
+  const [busyCaseNumber, setBusyCaseNumber] = useState<string | null>(null);
+  const [busyInvitationId, setBusyInvitationId] = useState<string | null>(null);
+  const [busyOrganizationId, setBusyOrganizationId] = useState<string | null>(null);
+  const [busyDeleteUserId, setBusyDeleteUserId] = useState<string | null>(null);
+
+  const isSuperAdmin = currentUser?.active_role === 'super_admin';
 
   const loadAdminData = async (isRefresh = false) => {
     if (isRefresh) {
@@ -69,17 +89,17 @@ export function AdminDashboard() {
     }
 
     try {
-      const [overviewData, organizationsData, usersData, rolesData] = await Promise.all([
-        getAdminOverview(),
+      const [organizationsData, usersData, rolesData, operationsData] = await Promise.all([
         getAdminOrganizations(100),
         getAdminUsers(200),
         getAdminRoles(),
+        getAdminOperations(),
       ]);
 
-      setOverview(overviewData);
       setOrganizations(organizationsData);
       setUsers(usersData);
       setRoles(rolesData);
+      setOperations(operationsData);
       setError(null);
 
       if (!userForm.organization_id && organizationsData.length > 0) {
@@ -88,6 +108,27 @@ export function AdminDashboard() {
           organization_id: organizationsData[0].id,
         }));
       }
+
+      setRoleDraftByUserId((previous) => {
+        const next = { ...previous };
+        for (const user of usersData) {
+          if (!next[user.id]) {
+            const firstMissingRole = rolesData.find((role) => !user.roles.includes(role.slug));
+            next[user.id] = firstMissingRole?.slug ?? rolesData[0]?.slug ?? 'lawyer';
+          }
+        }
+        return next;
+      });
+
+      setCaseAssignmentDraft((previous) => {
+        const next = { ...previous };
+        for (const caseItem of operationsData.unassigned_cases) {
+          if (!next[caseItem.case_number]) {
+            next[caseItem.case_number] = operationsData.lawyer_workload[0]?.lawyer_user_id ?? '';
+          }
+        }
+        return next;
+      });
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : 'Unknown error');
     } finally {
@@ -99,37 +140,7 @@ export function AdminDashboard() {
   useEffect(() => {
     void loadAdminData(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const stats = useMemo(
-    () => [
-      {
-        label: 'Organizations',
-        value: overview?.stats.organizations ?? 0,
-        icon: Building2,
-        color: 'text-blue-700 bg-blue-100',
-      },
-      {
-        label: 'Users',
-        value: overview?.stats.users ?? 0,
-        icon: Users,
-        color: 'text-indigo-700 bg-indigo-100',
-      },
-      {
-        label: 'Active Cases',
-        value: overview?.stats.active_cases ?? 0,
-        icon: Briefcase,
-        color: 'text-red-700 bg-red-100',
-      },
-      {
-        label: 'Completed Cases',
-        value: overview?.stats.completed_cases ?? 0,
-        icon: CheckCircle2,
-        color: 'text-green-700 bg-green-100',
-      },
-    ],
-    [overview]
-  );
+  }, [currentUser?.active_role]);
 
   const handleCreateOrganization = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -137,7 +148,7 @@ export function AdminDashboard() {
     try {
       const created = await createAdminOrganization({
         ...orgForm,
-        slug: orgForm.slug?.trim() ? orgForm.slug : null,
+        slug: orgForm.slug.trim(),
       });
       setOrgForm(initialOrgForm);
       setFlash({ kind: 'success', message: `Organization created: ${created.name}` });
@@ -166,6 +177,128 @@ export function AdminDashboard() {
         kind: 'error',
         message: createError instanceof Error ? createError.message : 'Failed to create user',
       });
+    }
+  };
+
+  const handleAssignRole = async (user: UserListItem) => {
+    const nextRole = roleDraftByUserId[user.id]?.trim();
+    if (!nextRole || user.roles.includes(nextRole)) {
+      return;
+    }
+
+    setBusyRoleUserId(user.id);
+    try {
+      await assignAdminRole(user.id, nextRole);
+      setFlash({ kind: 'success', message: `Assigned ${nextRole} to ${user.full_name}` });
+      await loadAdminData(true);
+    } catch (roleError) {
+      setFlash({
+        kind: 'error',
+        message: roleError instanceof Error ? roleError.message : 'Failed to assign role',
+      });
+    } finally {
+      setBusyRoleUserId(null);
+    }
+  };
+
+  const handleRemoveRole = async (user: UserListItem, roleSlug: string) => {
+    setBusyRoleUserId(user.id);
+    try {
+      await removeAdminRole(user.id, roleSlug);
+      setFlash({ kind: 'success', message: `Removed ${roleSlug} from ${user.full_name}` });
+      await loadAdminData(true);
+    } catch (roleError) {
+      setFlash({
+        kind: 'error',
+        message: roleError instanceof Error ? roleError.message : 'Failed to remove role',
+      });
+    } finally {
+      setBusyRoleUserId(null);
+    }
+  };
+
+  const handleAssignCase = async (caseNumber: string) => {
+    const selectedLawyerId = caseAssignmentDraft[caseNumber];
+    if (!selectedLawyerId) {
+      return;
+    }
+
+    setBusyCaseNumber(caseNumber);
+    try {
+      await assignAdminCaseLawyer(caseNumber, { lawyer_user_id: selectedLawyerId });
+      setFlash({ kind: 'success', message: `Assigned case ${caseNumber}` });
+      await loadAdminData(true);
+    } catch (assignError) {
+      setFlash({
+        kind: 'error',
+        message: assignError instanceof Error ? assignError.message : 'Failed to assign case',
+      });
+    } finally {
+      setBusyCaseNumber(null);
+    }
+  };
+
+  const handleDeleteOrganization = async (organization: OrganizationListItem) => {
+    if (!isSuperAdmin) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Delete organization \"${organization.name}\"? This blocks login for this organization.`
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setBusyOrganizationId(organization.id);
+    try {
+      await deleteAdminOrganization(organization.id);
+      setFlash({ kind: 'success', message: `Deleted organization: ${organization.name}` });
+      await loadAdminData(true);
+    } catch (deleteError) {
+      setFlash({
+        kind: 'error',
+        message: deleteError instanceof Error ? deleteError.message : 'Failed to delete organization',
+      });
+    } finally {
+      setBusyOrganizationId(null);
+    }
+  };
+
+  const handleDeleteUser = async (user: UserListItem) => {
+    const confirmed = window.confirm(`Delete user \"${user.full_name}\" (${user.email})?`);
+    if (!confirmed) {
+      return;
+    }
+
+    setBusyDeleteUserId(user.id);
+    try {
+      await deleteAdminUser(user.id);
+      setFlash({ kind: 'success', message: `Deleted user: ${user.full_name}` });
+      await loadAdminData(true);
+    } catch (deleteError) {
+      setFlash({
+        kind: 'error',
+        message: deleteError instanceof Error ? deleteError.message : 'Failed to delete user',
+      });
+    } finally {
+      setBusyDeleteUserId(null);
+    }
+  };
+
+  const handleRevokeInvitation = async (invitationId: string, email: string) => {
+    setBusyInvitationId(invitationId);
+    try {
+      await revokeAdminInvitation(invitationId);
+      setFlash({ kind: 'success', message: `Revoked invitation for ${email}` });
+      await loadAdminData(true);
+    } catch (inviteError) {
+      setFlash({
+        kind: 'error',
+        message: inviteError instanceof Error ? inviteError.message : 'Failed to revoke invitation',
+      });
+    } finally {
+      setBusyInvitationId(null);
     }
   };
 
@@ -214,84 +347,211 @@ export function AdminDashboard() {
           </div>
         ) : null}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
-          {stats.map((card) => (
-            <div key={card.label} className="bg-white rounded-lg shadow-sm p-6 border border-gray-100">
-              <div className="flex items-center justify-between mb-4">
-                <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${card.color}`}>
-                  <card.icon className="w-5 h-5" />
-                </div>
-              </div>
-              <div className="text-3xl font-bold text-gray-900 mb-1">{card.value}</div>
-              <div className="text-sm text-gray-600">{card.label}</div>
+        <div className="grid xl:grid-cols-2 gap-8">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-gray-900">Case Assignment Queue</h3>
             </div>
-          ))}
+            <div className="divide-y divide-gray-200">
+              {(operations?.unassigned_cases ?? []).length === 0 ? (
+                <div className="px-6 py-5 text-sm text-gray-500">No unassigned active cases.</div>
+              ) : (
+                (operations?.unassigned_cases ?? []).map((caseItem) => (
+                  <div key={caseItem.case_id} className="px-6 py-4 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-gray-900">{caseItem.case_number}</p>
+                      <p className="text-sm text-gray-600">
+                        {caseItem.case_type} • {caseItem.status} • Open {caseItem.days_open} days
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={caseAssignmentDraft[caseItem.case_number] ?? ''}
+                        onChange={(event) =>
+                          setCaseAssignmentDraft((previous) => ({
+                            ...previous,
+                            [caseItem.case_number]: event.target.value,
+                          }))
+                        }
+                        className="border border-gray-300 rounded-lg px-2 py-1 bg-white text-xs"
+                        disabled={(operations?.lawyer_workload ?? []).length === 0 || busyCaseNumber === caseItem.case_number}
+                      >
+                        {(operations?.lawyer_workload ?? []).length === 0 ? (
+                          <option value="">No lawyers available</option>
+                        ) : (
+                          (operations?.lawyer_workload ?? []).map((lawyer) => (
+                            <option key={lawyer.lawyer_user_id} value={lawyer.lawyer_user_id}>
+                              {lawyer.full_name} ({lawyer.active_cases})
+                            </option>
+                          ))
+                        )}
+                      </select>
+                      <button
+                        type="button"
+                        className="border border-gray-300 px-3 py-1 rounded-lg text-xs hover:bg-gray-100 disabled:opacity-50"
+                        disabled={busyCaseNumber === caseItem.case_number || !caseAssignmentDraft[caseItem.case_number]}
+                        onClick={() => void handleAssignCase(caseItem.case_number)}
+                      >
+                        Assign
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-gray-900">Lawyer Workload</h3>
+            </div>
+            <div className="divide-y divide-gray-200">
+              {(operations?.lawyer_workload ?? []).length === 0 ? (
+                <div className="px-6 py-5 text-sm text-gray-500">No active lawyers found.</div>
+              ) : (
+                (operations?.lawyer_workload ?? [])
+                  .slice()
+                  .sort((a, b) => b.active_cases - a.active_cases)
+                  .map((lawyer) => (
+                    <div key={lawyer.lawyer_user_id} className="px-6 py-4 flex items-center justify-between">
+                      <p className="text-sm text-gray-800">{lawyer.full_name}</p>
+                      <span className="text-sm font-semibold text-gray-900">{lawyer.active_cases} active</span>
+                    </div>
+                  ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid xl:grid-cols-2 gap-8">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-gray-900">Aging Cases</h3>
+            </div>
+            <div className="divide-y divide-gray-200">
+              {(operations?.aging_cases ?? []).length === 0 ? (
+                <div className="px-6 py-5 text-sm text-gray-500">No active cases found.</div>
+              ) : (
+                (operations?.aging_cases ?? []).slice(0, 12).map((caseItem) => (
+                  <div key={caseItem.case_id} className="px-6 py-4">
+                    <p className="font-medium text-gray-900">{caseItem.case_number}</p>
+                    <p className="text-sm text-gray-600">
+                      {caseItem.case_type} • {caseItem.status} • {caseItem.days_open} days open
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Lawyer: {caseItem.primary_lawyer_name ?? 'Unassigned'}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-gray-900">Pending Invitations</h3>
+            </div>
+            <div className="divide-y divide-gray-200">
+              {(operations?.pending_invitations ?? []).length === 0 ? (
+                <div className="px-6 py-5 text-sm text-gray-500">No pending invitations.</div>
+              ) : (
+                (operations?.pending_invitations ?? []).map((invite) => (
+                  <div key={invite.invitation_id} className="px-6 py-4 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-gray-900">{invite.email}</p>
+                      <p className="text-sm text-gray-600">
+                        {invite.role_slug} • Sent {formatDate(invite.created_at)} • Expires {formatDate(invite.expires_at)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      className="border border-red-200 text-red-700 px-3 py-1 rounded-lg text-xs hover:bg-red-50 disabled:opacity-50"
+                      disabled={busyInvitationId === invite.invitation_id}
+                      onClick={() => void handleRevokeInvitation(invite.invitation_id, invite.email)}
+                    >
+                      Revoke
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-8">
-          <form onSubmit={handleCreateOrganization} className="bg-white rounded-lg shadow-sm border border-gray-100 p-6 space-y-4">
-            <h2 className="text-lg font-semibold text-gray-900">Create Organization</h2>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Organization Name</label>
-              <input
-                required
-                type="text"
-                value={orgForm.name}
-                onChange={(event) => setOrgForm((previous) => ({ ...previous, name: event.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Contact Email</label>
-              <input
-                required
-                type="email"
-                value={orgForm.contact_email}
-                onChange={(event) => setOrgForm((previous) => ({ ...previous, contact_email: event.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Slug (optional)</label>
-              <input
-                type="text"
-                value={orgForm.slug ?? ''}
-                onChange={(event) => setOrgForm((previous) => ({ ...previous, slug: event.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
-                placeholder="acme-immigration"
-              />
-            </div>
-            <div className="grid grid-cols-2 gap-3">
+          {isSuperAdmin ? (
+            <form onSubmit={handleCreateOrganization} className="bg-white rounded-lg shadow-sm border border-gray-100 p-6 space-y-4">
+              <h2 className="text-lg font-semibold text-gray-900">Create Organization</h2>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Tier</label>
-                <select
-                  value={orgForm.subscription_tier}
-                  onChange={(event) => setOrgForm((previous) => ({ ...previous, subscription_tier: event.target.value }))}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 bg-white"
-                >
-                  <option value="basic">Basic</option>
-                  <option value="pro">Pro</option>
-                  <option value="enterprise">Enterprise</option>
-                </select>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Organization Name</label>
+                <input
+                  required
+                  type="text"
+                  value={orgForm.name}
+                  onChange={(event) => setOrgForm((previous) => ({ ...previous, name: event.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
-                <select
-                  value={orgForm.subscription_status}
-                  onChange={(event) => setOrgForm((previous) => ({ ...previous, subscription_status: event.target.value }))}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 bg-white"
-                >
-                  <option value="active">Active</option>
-                  <option value="trial">Trial</option>
-                  <option value="suspended">Suspended</option>
-                  <option value="cancelled">Cancelled</option>
-                </select>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Contact Email</label>
+                <input
+                  required
+                  type="email"
+                  value={orgForm.contact_email}
+                  onChange={(event) => setOrgForm((previous) => ({ ...previous, contact_email: event.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
+                />
               </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Slug</label>
+                <input
+                  required
+                  type="text"
+                  value={orgForm.slug}
+                  onChange={(event) => setOrgForm((previous) => ({ ...previous, slug: event.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
+                  placeholder="acme-immigration"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Tier</label>
+                  <select
+                    value={orgForm.subscription_tier}
+                    onChange={(event) => setOrgForm((previous) => ({ ...previous, subscription_tier: event.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 bg-white"
+                  >
+                    <option value="basic">Basic</option>
+                    <option value="pro">Pro</option>
+                    <option value="enterprise">Enterprise</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                  <select
+                    value={orgForm.subscription_status}
+                    onChange={(event) => setOrgForm((previous) => ({ ...previous, subscription_status: event.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 bg-white"
+                  >
+                    <option value="active">Active</option>
+                    <option value="trial">Trial</option>
+                    <option value="suspended">Suspended</option>
+                    <option value="cancelled">Cancelled</option>
+                  </select>
+                </div>
+              </div>
+              <button type="submit" className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors">
+                Create Organization
+              </button>
+            </form>
+          ) : (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
+              <h2 className="text-lg font-semibold text-gray-900">Organization Scope</h2>
+              <p className="mt-2 text-sm text-gray-600">
+                Organization admins can manage users and case operations only for their own organization.
+              </p>
             </div>
-            <button type="submit" className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg transition-colors">
-              Create Organization
-            </button>
-          </form>
+          )}
 
           <form onSubmit={handleCreateUser} className="bg-white rounded-lg shadow-sm border border-gray-100 p-6 space-y-4">
             <h2 className="text-lg font-semibold text-gray-900">Create User</h2>
@@ -394,34 +654,46 @@ export function AdminDashboard() {
         </div>
 
         <div className="grid xl:grid-cols-2 gap-8">
-          <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-200">
-              <h3 className="font-semibold text-gray-900">Organizations</h3>
-            </div>
-            <div className="divide-y divide-gray-200">
-              {(overview?.recent_organizations ?? []).map((organization) => (
-                <div key={organization.id} className="px-6 py-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="font-medium text-gray-900">{organization.name}</p>
-                      <p className="text-sm text-gray-600">{organization.slug} • {organization.contact_email}</p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-xs text-gray-500">{formatDate(organization.created_at)}</p>
-                      <p className="text-xs font-medium text-green-700">{organization.subscription_status}</p>
+          {isSuperAdmin ? (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
+              <div className="px-6 py-4 border-b border-gray-200">
+                <h3 className="font-semibold text-gray-900">Organizations</h3>
+              </div>
+              <div className="divide-y divide-gray-200">
+                {organizations.map((organization) => (
+                  <div key={organization.id} className="px-6 py-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-900">{organization.name}</p>
+                        <p className="text-sm text-gray-600">{organization.slug} • {organization.contact_email}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-xs text-gray-500">{formatDate(organization.created_at)}</p>
+                        <p className="text-xs font-medium text-green-700">{organization.subscription_status}</p>
+                        <button
+                          type="button"
+                          className="mt-2 border border-red-200 text-red-700 px-3 py-1 rounded-lg text-xs hover:bg-red-50 disabled:opacity-50"
+                          disabled={
+                            busyOrganizationId === organization.id || currentUser?.organization_id === organization.id
+                          }
+                          onClick={() => void handleDeleteOrganization(organization)}
+                        >
+                          Delete
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </div>
+          ) : null}
 
           <div className="bg-white rounded-lg shadow-sm border border-gray-100 overflow-hidden">
             <div className="px-6 py-4 border-b border-gray-200">
               <h3 className="font-semibold text-gray-900">Recent Users</h3>
             </div>
             <div className="divide-y divide-gray-200">
-              {(overview?.recent_users ?? []).map((user) => (
+              {users.slice(0, 8).map((user) => (
                 <div key={user.id} className="px-6 py-4">
                   <div className="flex items-center justify-between">
                     <div>
@@ -450,20 +722,89 @@ export function AdminDashboard() {
                   <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Name</th>
                   <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Email</th>
                   <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Organization</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Roles</th>
                   <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Status</th>
                   <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Created</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Manage Roles</th>
+                  <th className="text-left px-6 py-3 text-xs font-semibold text-gray-700 uppercase">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {users.map((user) => {
                   const organization = organizations.find((entry) => entry.id === user.organization_id);
+                  const assignableRoles = roles.filter((role) => !user.roles.includes(role.slug));
+                  const selectedRole = roleDraftByUserId[user.id] ?? assignableRoles[0]?.slug ?? '';
+                  const roleBusy = busyRoleUserId === user.id;
                   return (
                     <tr key={user.id} className="hover:bg-gray-50">
                       <td className="px-6 py-4 text-sm font-medium text-gray-900">{user.full_name}</td>
                       <td className="px-6 py-4 text-sm text-gray-700">{user.email}</td>
                       <td className="px-6 py-4 text-sm text-gray-700">{organization?.name ?? 'N/A'}</td>
+                      <td className="px-6 py-4 text-sm text-gray-700">
+                        <div className="flex flex-wrap gap-2">
+                          {user.roles.length === 0 ? (
+                            <span className="text-xs text-gray-500">No roles</span>
+                          ) : (
+                            user.roles.map((role) => (
+                              <button
+                                key={role}
+                                type="button"
+                                onClick={() => void handleRemoveRole(user, role)}
+                                className="inline-flex items-center rounded-full border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+                                disabled={roleBusy}
+                                title="Remove role"
+                              >
+                                {role} ×
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      </td>
                       <td className="px-6 py-4 text-sm text-gray-700">{user.status}</td>
                       <td className="px-6 py-4 text-sm text-gray-500">{formatDate(user.created_at)}</td>
+                      <td className="px-6 py-4 text-sm text-gray-700">
+                        <div className="flex items-center gap-2">
+                          <select
+                            value={selectedRole}
+                            onChange={(event) =>
+                              setRoleDraftByUserId((previous) => ({
+                                ...previous,
+                                [user.id]: event.target.value,
+                              }))
+                            }
+                            className="border border-gray-300 rounded-lg px-2 py-1 bg-white text-xs"
+                            disabled={roleBusy || assignableRoles.length === 0}
+                          >
+                            {assignableRoles.length === 0 ? (
+                              <option value="">No available roles</option>
+                            ) : (
+                              assignableRoles.map((role) => (
+                                <option key={role.id} value={role.slug}>
+                                  {role.name}
+                                </option>
+                              ))
+                            )}
+                          </select>
+                          <button
+                            type="button"
+                            className="border border-gray-300 px-3 py-1 rounded-lg text-xs hover:bg-gray-100 disabled:opacity-50"
+                            disabled={roleBusy || !selectedRole || assignableRoles.length === 0}
+                            onClick={() => void handleAssignRole(user)}
+                          >
+                            Add
+                          </button>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-700">
+                        <button
+                          type="button"
+                          className="border border-red-200 text-red-700 px-3 py-1 rounded-lg text-xs hover:bg-red-50 disabled:opacity-50"
+                          disabled={busyDeleteUserId === user.id || currentUser?.id === user.id}
+                          onClick={() => void handleDeleteUser(user)}
+                        >
+                          Delete
+                        </button>
+                      </td>
                     </tr>
                   );
                 })}

--- a/frontend/figma/components/LawyerDashboard.tsx
+++ b/frontend/figma/components/LawyerDashboard.tsx
@@ -10,9 +10,6 @@ import { useLawyerDashboardData } from './lawyer-dashboard/useLawyerDashboardDat
 interface LawyerDashboardProps {
   onViewActiveCases?: () => void;
   onSelectCase?: (caseId: string) => void;
-  onViewMessages?: () => void;
-  onScheduleAppointment?: () => void;
-  onAddClient?: () => void | Promise<void>;
   onCreateCase?: () => void | Promise<void>;
   lawyerName?: string;
 }
@@ -20,14 +17,16 @@ interface LawyerDashboardProps {
 export function LawyerDashboard({
   onViewActiveCases,
   onSelectCase,
-  onViewMessages,
-  onScheduleAppointment,
-  onAddClient,
   onCreateCase,
   lawyerName,
 }: LawyerDashboardProps) {
   const { cases, stats, upcomingDeadlines, derivedActivity, isLoading, error, retry } = useLawyerDashboardData();
   const displayName = lawyerName?.trim().split(/\s+/)[0] || 'Attorney';
+  const nextDeadlineCaseId = [...upcomingDeadlines].sort((left, right) => left.daysLeft - right.daysLeft)[0]?.client;
+  const highestPriorityCaseId =
+    cases.find((entry) => entry.priority.toLowerCase() === 'high')?.id ??
+    cases.find((entry) => entry.priority.toLowerCase() === 'medium')?.id ??
+    cases[0]?.id;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -82,9 +81,21 @@ export function LawyerDashboard({
             <UpcomingDeadlinesPanel deadlines={upcomingDeadlines} isLoading={isLoading} />
             <QuickActionsPanel
               onCreateCase={onCreateCase}
-              onAddClient={onAddClient ?? onCreateCase}
-              onViewMessages={onViewMessages ?? onViewActiveCases}
-              onScheduleAppointment={onScheduleAppointment ?? onViewActiveCases}
+              onViewActiveCases={onViewActiveCases}
+              onOpenNextDeadlineCase={
+                nextDeadlineCaseId
+                  ? () => {
+                      onSelectCase?.(nextDeadlineCaseId);
+                    }
+                  : undefined
+              }
+              onOpenHighPriorityCase={
+                highestPriorityCaseId
+                  ? () => {
+                      onSelectCase?.(highestPriorityCaseId);
+                    }
+                  : undefined
+              }
             />
           </div>
         </div>

--- a/frontend/figma/components/lawyer-dashboard/QuickActionsPanel.tsx
+++ b/frontend/figma/components/lawyer-dashboard/QuickActionsPanel.tsx
@@ -1,17 +1,17 @@
-import { Calendar, FileText, MessageSquare, Users } from 'lucide-react';
+import { AlertTriangle, FilePlus2, Flag, FolderOpen } from 'lucide-react';
 
 type QuickActionsPanelProps = {
   onCreateCase?: () => void | Promise<void>;
-  onAddClient?: () => void | Promise<void>;
-  onViewMessages?: () => void;
-  onScheduleAppointment?: () => void;
+  onViewActiveCases?: () => void;
+  onOpenNextDeadlineCase?: () => void;
+  onOpenHighPriorityCase?: () => void;
 };
 
 export function QuickActionsPanel({
   onCreateCase,
-  onAddClient,
-  onViewMessages,
-  onScheduleAppointment,
+  onViewActiveCases,
+  onOpenNextDeadlineCase,
+  onOpenHighPriorityCase,
 }: QuickActionsPanelProps) {
   return (
     <div className="bg-white rounded-lg shadow-sm p-6">
@@ -24,34 +24,34 @@ export function QuickActionsPanel({
           }}
           type="button"
         >
-          <FileText className="w-5 h-5 text-gray-600" />
+          <FilePlus2 className="w-5 h-5 text-gray-600" />
           <span className="text-sm font-medium text-gray-900">Create New Case</span>
         </button>
         <button
           className="w-full flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors text-left"
-          onClick={() => {
-            void onAddClient?.();
-          }}
+          onClick={onViewActiveCases}
           type="button"
         >
-          <Users className="w-5 h-5 text-gray-600" />
-          <span className="text-sm font-medium text-gray-900">Add New Client</span>
+          <FolderOpen className="w-5 h-5 text-gray-600" />
+          <span className="text-sm font-medium text-gray-900">View Active Cases</span>
         </button>
         <button
-          className="w-full flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors text-left"
-          onClick={onViewMessages}
+          className="w-full flex items-center gap-3 p-3 border border-gray-200 rounded-lg transition-colors text-left disabled:opacity-60 disabled:cursor-not-allowed enabled:hover:bg-gray-50"
+          onClick={onOpenNextDeadlineCase}
+          disabled={!onOpenNextDeadlineCase}
           type="button"
         >
-          <MessageSquare className="w-5 h-5 text-gray-600" />
-          <span className="text-sm font-medium text-gray-900">View Messages</span>
+          <AlertTriangle className="w-5 h-5 text-gray-600" />
+          <span className="text-sm font-medium text-gray-900">Open Next Deadline Case</span>
         </button>
         <button
-          className="w-full flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors text-left"
-          onClick={onScheduleAppointment}
+          className="w-full flex items-center gap-3 p-3 border border-gray-200 rounded-lg transition-colors text-left disabled:opacity-60 disabled:cursor-not-allowed enabled:hover:bg-gray-50"
+          onClick={onOpenHighPriorityCase}
+          disabled={!onOpenHighPriorityCase}
           type="button"
         >
-          <Calendar className="w-5 h-5 text-gray-600" />
-          <span className="text-sm font-medium text-gray-900">Schedule Appointment</span>
+          <Flag className="w-5 h-5 text-gray-600" />
+          <span className="text-sm font-medium text-gray-900">Open Highest Priority Case</span>
         </button>
       </div>
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -113,6 +113,7 @@ export type UserListItem = {
   status: string;
   organization_id: string | null;
   created_at: string;
+  roles: string[];
 };
 
 export type AdminOverview = {
@@ -163,7 +164,7 @@ export type AdminRoleItem = {
 export type AdminCreateOrganizationInput = {
   name: string;
   contact_email: string;
-  slug?: string | null;
+  slug: string;
   subscription_tier?: string;
   subscription_status?: string;
 };
@@ -176,6 +177,58 @@ export type AdminCreateUserInput = {
   password: string;
   status?: string;
   role_slug?: string;
+};
+
+export type AdminOperations = {
+  organization_id: string;
+  unassigned_cases: Array<{
+    case_id: string;
+    case_number: string;
+    case_type: string;
+    status: string;
+    priority: string;
+    created_at: string;
+    days_open: number;
+    primary_lawyer_id: string | null;
+    primary_lawyer_name: string | null;
+  }>;
+  aging_cases: Array<{
+    case_id: string;
+    case_number: string;
+    case_type: string;
+    status: string;
+    priority: string;
+    created_at: string;
+    days_open: number;
+    primary_lawyer_id: string | null;
+    primary_lawyer_name: string | null;
+  }>;
+  lawyer_workload: Array<{
+    lawyer_user_id: string;
+    full_name: string;
+    active_cases: number;
+  }>;
+  pending_invitations: Array<{
+    invitation_id: string;
+    user_id: string;
+    email: string;
+    role_slug: string;
+    created_at: string;
+    expires_at: string;
+    status: string;
+    invited_by_name: string | null;
+  }>;
+};
+
+export type AdminCaseAssignmentInput = {
+  lawyer_user_id: string | null;
+};
+
+export type AdminCaseAssignmentResult = {
+  case_id: string;
+  case_number: string;
+  primary_lawyer_id: string | null;
+  primary_lawyer_name: string | null;
 };
 
 export type MilestoneSummary = {
@@ -440,8 +493,17 @@ export type CurrentUser = {
   full_name: string;
   status: string;
   roles: string[];
+  active_role: string;
   onboarding_required: boolean;
   last_login_at: string | null;
+};
+
+export type SwitchActiveRoleResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in_seconds: number;
+  active_role: string;
+  roles: string[];
 };
 
 export type CurrentUserSettings = {
@@ -639,6 +701,15 @@ export async function getCurrentUser(): Promise<CurrentUser> {
   return requestJson<CurrentUser>('/api/v1/auth/me');
 }
 
+export async function switchActiveRole(role: string): Promise<SwitchActiveRoleResponse> {
+  const response = await requestJson<SwitchActiveRoleResponse>('/api/v1/auth/switch-role', {
+    method: 'POST',
+    body: JSON.stringify({ role }),
+  });
+  setAccessToken(response.access_token);
+  return response;
+}
+
 export async function getCurrentUserSettings(): Promise<CurrentUserSettings> {
   return requestJson<CurrentUserSettings>('/api/v1/auth/me/settings');
 }
@@ -723,6 +794,11 @@ export async function getAdminOverview(): Promise<AdminOverview> {
   return requestJson<AdminOverview>('/api/v1/admin/overview');
 }
 
+export async function getAdminOperations(organizationId?: string): Promise<AdminOperations> {
+  const query = organizationId ? `?organization_id=${encodeURIComponent(organizationId)}` : '';
+  return requestJson<AdminOperations>(`/api/v1/admin/operations${query}`);
+}
+
 export async function getAdminOrganizations(limit = 50): Promise<OrganizationListItem[]> {
   return requestJson<OrganizationListItem[]>(`/api/v1/admin/organizations?limit=${limit}`);
 }
@@ -744,6 +820,12 @@ export async function createAdminOrganization(
   });
 }
 
+export async function deleteAdminOrganization(organizationId: string): Promise<void> {
+  return requestVoid(`/api/v1/admin/organizations/${encodeURIComponent(organizationId)}`, {
+    method: 'DELETE',
+  });
+}
+
 export async function createAdminUser(input: AdminCreateUserInput): Promise<UserListItem> {
   return requestJson<UserListItem>('/api/v1/admin/users', {
     method: 'POST',
@@ -751,10 +833,41 @@ export async function createAdminUser(input: AdminCreateUserInput): Promise<User
   });
 }
 
+export async function deleteAdminUser(userId: string): Promise<void> {
+  return requestVoid(`/api/v1/admin/users/${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+  });
+}
+
 export async function assignAdminRole(userId: string, roleSlug: string): Promise<void> {
   return requestVoid(`/api/v1/admin/users/${encodeURIComponent(userId)}/roles`, {
     method: 'POST',
     body: JSON.stringify({ role_slug: roleSlug }),
+  });
+}
+
+export async function removeAdminRole(userId: string, roleSlug: string): Promise<void> {
+  return requestVoid(
+    `/api/v1/admin/users/${encodeURIComponent(userId)}/roles/${encodeURIComponent(roleSlug)}`,
+    {
+      method: 'DELETE',
+    }
+  );
+}
+
+export async function assignAdminCaseLawyer(
+  caseNumber: string,
+  input: AdminCaseAssignmentInput
+): Promise<AdminCaseAssignmentResult> {
+  return requestJson<AdminCaseAssignmentResult>(`/api/v1/admin/cases/${encodeURIComponent(caseNumber)}/assign`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export async function revokeAdminInvitation(invitationId: string): Promise<void> {
+  return requestVoid(`/api/v1/admin/invitations/${encodeURIComponent(invitationId)}/revoke`, {
+    method: 'POST',
   });
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,6 +69,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1623,6 +1624,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1682,6 +1684,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2181,6 +2184,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2467,6 +2471,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2531,6 +2536,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3098,6 +3104,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3283,6 +3290,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5464,6 +5472,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5473,6 +5482,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6161,6 +6171,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6323,6 +6334,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6598,6 +6610,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
This PR improves the admin experience and tightens backend role/scope behavior across admin operations.
I had to step in and do this since it was holding up my development

## What changed

- Replaced header role dropdown with a segmented slider-style role switch.
- Added automatic admin data refresh when active role changes.
- Removed admin stats cards from the admin panel UI.
- Made organization slug required when creating organizations.
- Added delete actions for organizations and users (soft-delete behavior).
- Restricted organization creation/deletion to active super_admin scope.
- Clarified effective role behavior between org_admin and super_admin.
- Added role slug canonicalization (admin → org_admin) to avoid legacy role mismatch issues.
- Aligned admin user role listing with auth role-scope logic so displayed roles match effective login roles.
- Removed temporary role debug output from the header.

## Why

- Fixes confusion around missing orgs/users due to role scope.
- Prevents UI/backend mismatch in perceived vs effective permissions.
- Enforces required login-critical org slug at creation time.
- Adds missing destructive management actions requested for admin workflows.

## Validation
 
- Existing frontend lint had previously been passing.
- No temporary debug UI remains.