### PR TITLE
Admin/sending invite to user

### DIFF
--- a/backend/alembic/versions/76b6cea54557_add_jurisdiction_to_user_profiles.py
+++ b/backend/alembic/versions/76b6cea54557_add_jurisdiction_to_user_profiles.py
@@ -1,0 +1,26 @@
+"""add_jurisdiction_to_user_profiles
+
+Revision ID: 76b6cea54557
+Revises: e92b3ac1b42b
+Create Date: 2026-03-14 22:33:03.677232
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '76b6cea54557'
+down_revision: Union[str, Sequence[str], None] = 'e92b3ac1b42b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('user_profiles', sa.Column('jurisdiction', sa.String(100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('user_profiles', 'jurisdiction')

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -597,6 +597,7 @@ def send_invitation_email_endpoint(
             to_email=payload.to_email,
             recipient_name=payload.recipient_name,
             invitation_url=payload.invitation_url,
+            organization_name=payload.organization_name or "VisaTrack",
         )
     except EmailNotConfiguredError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -8,7 +8,8 @@ from sqlalchemy import String, and_, cast, func, select
 from sqlalchemy.orm import Session, aliased
 
 from app.api.deps.auth import AuthContext, require_permissions, require_roles
-from app.core.security import hash_password
+from app.core.config import settings
+from app.core.security import generate_invitation_token, hash_invitation_token, hash_password
 from app.db.deps import get_db
 from app.models.case import Case
 from app.models.organization import Organization
@@ -22,6 +23,7 @@ from app.schemas.admin import (
     AdminCaseAssignmentResponse,
     AdminCreateOrganizationRequest,
     AdminCreateUserRequest,
+    AdminCreateUserResponse,
     AdminOperationsResponse,
     AdminOpsCaseItem,
     AdminOpsInvitationItem,
@@ -641,13 +643,19 @@ def list_admin_users(
     ]
 
 
-@router.post("/users", response_model=UserListItem, status_code=status.HTTP_201_CREATED)
+@router.post("/users", response_model=AdminCreateUserResponse, status_code=status.HTTP_201_CREATED)
 def create_user(
     payload: AdminCreateUserRequest,
     auth: AuthContext = Depends(require_permissions("users:manage")),
     db: Session = Depends(get_db),
-) -> UserListItem:
+) -> AdminCreateUserResponse:
     _require_org_scope(auth, payload.organization_id)
+
+    normalized_status = payload.status.strip().lower()
+    is_invited = normalized_status == "invited"
+
+    if not is_invited and not payload.password:
+        raise HTTPException(status_code=400, detail="Password is required for non-invited users")
 
     organization_exists = db.scalar(
         select(Organization.id).where(
@@ -669,10 +677,13 @@ def create_user(
     if existing_user is not None:
         raise HTTPException(status_code=409, detail="User email already exists in organization")
 
-    try:
-        password_hash = hash_password(payload.password)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if is_invited:
+        password_hash = hash_password(generate_invitation_token())
+    else:
+        try:
+            password_hash = hash_password(payload.password)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     new_user = User(
         organization_id=payload.organization_id,
@@ -680,7 +691,7 @@ def create_user(
         password_hash=password_hash,
         first_name=payload.first_name.strip(),
         last_name=payload.last_name.strip(),
-        status=payload.status.strip().lower(),
+        status=normalized_status,
     )
     db.add(new_user)
     db.flush()
@@ -692,6 +703,22 @@ def create_user(
         assigned_by=auth.user_id,
     )
 
+    invitation_url: str | None = None
+    if is_invited:
+        now = datetime.now(timezone.utc)
+        plain_token = generate_invitation_token()
+        invitation = UserInvitation(
+            organization_id=payload.organization_id,
+            user_id=new_user.id,
+            email=normalized_email,
+            role_slug=payload.role_slug.strip().lower(),
+            token_hash=hash_invitation_token(plain_token),
+            expires_at=now + timedelta(hours=settings.invitation_expiry_hours),
+            invited_by=auth.user_id,
+        )
+        db.add(invitation)
+        invitation_url = f"{settings.frontend_origin}/invite?token={plain_token}"
+
     log_activity(
         db,
         organization_id=payload.organization_id,
@@ -699,13 +726,13 @@ def create_user(
         action="created",
         entity_type="user",
         entity_id=new_user.id,
-        new_values={"email": new_user.email, "role": payload.role_slug.strip().lower()},
+        new_values={"email": new_user.email, "role": payload.role_slug.strip().lower(), "invited": is_invited},
     )
 
     db.commit()
     db.refresh(new_user)
 
-    return UserListItem(
+    return AdminCreateUserResponse(
         id=new_user.id,
         email=new_user.email,
         full_name=f"{new_user.first_name} {new_user.last_name}",
@@ -713,6 +740,7 @@ def create_user(
         organization_id=new_user.organization_id,
         created_at=new_user.created_at,
         roles=[payload.role_slug.strip().lower()],
+        invitation_url=invitation_url,
     )
 
 

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -25,6 +25,7 @@ from app.schemas.admin import (
     AdminCreateUserRequest,
     AdminCreateUserResponse,
     AdminOperationsResponse,
+    SendInvitationEmailRequest,
     AdminOpsCaseItem,
     AdminOpsInvitationItem,
     AdminOpsLawyerWorkloadItem,
@@ -38,6 +39,7 @@ from app.schemas.admin import (
 from app.schemas.organization import OrganizationRead
 from app.schemas.user import UserListItem
 from app.services.audit import log_activity
+from app.services.email import EmailNotConfiguredError, send_invitation_email
 from app.services.rbac import assign_role_to_user, canonical_role_slug, revoke_role_from_user
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -585,6 +587,23 @@ def revoke_invitation(
     db.commit()
 
 
+@router.post("/send-invitation-email", status_code=status.HTTP_204_NO_CONTENT)
+def send_invitation_email_endpoint(
+    payload: SendInvitationEmailRequest,
+    auth: AuthContext = Depends(require_roles("org_admin", "super_admin")),
+) -> None:
+    try:
+        send_invitation_email(
+            to_email=payload.to_email,
+            recipient_name=payload.recipient_name,
+            invitation_url=payload.invitation_url,
+        )
+    except EmailNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to send email: {exc}") from exc
+
+
 @router.get("/roles", response_model=list[AdminRoleItem])
 def list_roles(
     auth: AuthContext = Depends(require_permissions("roles:manage")),
@@ -717,7 +736,8 @@ def create_user(
             invited_by=auth.user_id,
         )
         db.add(invitation)
-        invitation_url = f"{settings.frontend_origin}/invite?token={plain_token}"
+        primary_origin = settings.frontend_origin.split(",")[0].strip().rstrip("/")
+        invitation_url = f"{primary_origin}/invite?token={plain_token}"
 
     log_activity(
         db,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -32,6 +32,7 @@ from app.schemas.auth import (
     SwitchActiveRoleRequest,
     SwitchActiveRoleResponse,
     UpdateCurrentUserSettingsRequest,
+    VerifyInvitationResponse,
 )
 from app.services.audit import log_activity
 from app.services.rbac import canonical_role_slug, select_default_active_role
@@ -312,6 +313,41 @@ def change_password(
     auth.user.updated_at = datetime.now(timezone.utc)
     db.add(auth.user)
     db.commit()
+
+
+@router.get("/verify-invitation", response_model=VerifyInvitationResponse)
+def verify_invitation(
+    token: str,
+    db: Session = Depends(get_db),
+) -> VerifyInvitationResponse:
+    now = datetime.now(timezone.utc)
+    token_hash = hash_invitation_token(token)
+
+    invitation = db.scalar(
+        select(UserInvitation).where(
+            UserInvitation.token_hash == token_hash,
+            UserInvitation.accepted_at.is_(None),
+            UserInvitation.revoked_at.is_(None),
+        )
+    )
+    if invitation is None:
+        raise HTTPException(status_code=400, detail="Invitation is invalid")
+
+    if invitation.expires_at < now:
+        raise HTTPException(status_code=400, detail="Invitation has expired")
+
+    user = db.scalar(
+        select(User).where(User.id == invitation.user_id, User.deleted_at.is_(None))
+    )
+    if user is None:
+        raise HTTPException(status_code=400, detail="Invited user no longer exists")
+
+    return VerifyInvitationResponse(
+        email=user.email,
+        full_name=f"{user.first_name} {user.last_name}",
+        organization_id=user.organization_id,
+        expires_at=invitation.expires_at,
+    )
 
 
 @router.post("/accept-invitation", response_model=AcceptInvitationResponse)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,9 @@ class Settings:
     s3_endpoint_url: str = os.getenv("S3_ENDPOINT_URL", "")
     s3_presign_expires_seconds: int = int(os.getenv("S3_PRESIGN_EXPIRES_SECONDS", "900"))
     s3_max_upload_bytes: int = int(os.getenv("S3_MAX_UPLOAD_BYTES", str(25 * 1024 * 1024)))
+    resend_api_key: str = os.getenv("RESEND_API_KEY", "")
+    resend_from_email: str = os.getenv("RESEND_FROM_EMAIL", "noreply@visatrack.app")
+    resend_from_name: str = os.getenv("RESEND_FROM_NAME", "VisaTrack")
 
     @property
     def frontend_origins(self) -> list[str]:

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -135,6 +135,7 @@ class SendInvitationEmailRequest(BaseModel):
     to_email: str = Field(min_length=3, max_length=255)
     recipient_name: str = Field(min_length=1, max_length=200)
     invitation_url: str = Field(min_length=10, max_length=2000)
+    organization_name: Optional[str] = Field(default=None, max_length=255)
 
 
 class AdminOperationsResponse(BaseModel):

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -131,6 +131,12 @@ class AdminOpsInvitationItem(BaseModel):
     invited_by_name: Optional[str]
 
 
+class SendInvitationEmailRequest(BaseModel):
+    to_email: str = Field(min_length=3, max_length=255)
+    recipient_name: str = Field(min_length=1, max_length=200)
+    invitation_url: str = Field(min_length=10, max_length=2000)
+
+
 class AdminOperationsResponse(BaseModel):
     organization_id: UUID
     unassigned_cases: list[AdminOpsCaseItem]

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -18,9 +18,20 @@ class AdminCreateUserRequest(BaseModel):
     email: str = Field(min_length=3, max_length=255)
     first_name: str = Field(min_length=1, max_length=100)
     last_name: str = Field(min_length=1, max_length=100)
-    password: str = Field(min_length=8, max_length=128)
+    password: Optional[str] = Field(default=None, min_length=8, max_length=128)
     status: str = Field(default="active", min_length=2, max_length=50)
     role_slug: str = Field(default="lawyer", min_length=2, max_length=100)
+
+
+class AdminCreateUserResponse(BaseModel):
+    id: UUID
+    email: str
+    full_name: str
+    status: str
+    organization_id: Optional[UUID]
+    created_at: datetime
+    roles: list[str] = Field(default_factory=list)
+    invitation_url: Optional[str] = None
 
 
 class AdminOverviewStats(BaseModel):

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -82,3 +82,10 @@ class AcceptInvitationResponse(BaseModel):
     message: str
     email: str
     organization_id: UUID
+
+
+class VerifyInvitationResponse(BaseModel):
+    email: str
+    full_name: str
+    organization_id: UUID
+    expires_at: datetime

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+
+import resend
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class EmailNotConfiguredError(Exception):
+    pass
+
+
+def send_invitation_email(
+    to_email: str,
+    recipient_name: str,
+    invitation_url: str,
+    organization_name: str = "VisaTrack",
+) -> None:
+    """Send an invitation email via Resend.
+
+    Raises EmailNotConfiguredError if RESEND_API_KEY is not set.
+    Raises resend.exceptions.ResendError on API/delivery failure.
+    """
+    if not settings.resend_api_key:
+        raise EmailNotConfiguredError(
+            "Resend is not configured. Set RESEND_API_KEY in your environment."
+        )
+
+    resend.api_key = settings.resend_api_key
+
+    from_address = f"{settings.resend_from_name} <{settings.resend_from_email}>"
+
+    plain = (
+        f"Hi {recipient_name},\n\n"
+        f"You have been invited to join {organization_name} on VisaTrack. "
+        f"Click the link below to set your password and activate your account.\n\n"
+        f"{invitation_url}\n\n"
+        f"This link expires in 72 hours. If you did not expect this invitation, "
+        f"you can safely ignore this email.\n\n"
+        f"— The {organization_name} Team"
+    )
+
+    html = f"""<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; color: #111; max-width: 520px; margin: 0 auto; padding: 24px;">
+  <h2 style="margin-bottom: 8px;">You have been invited to join {organization_name}</h2>
+  <p>Hi {recipient_name},</p>
+  <p>
+    You have been invited to join <strong>{organization_name}</strong> on VisaTrack.
+    Click the button below to set your password and activate your account.
+  </p>
+  <p style="margin: 28px 0;">
+    <a href="{invitation_url}"
+       style="background:#dc2626;color:#fff;padding:12px 24px;border-radius:8px;
+              text-decoration:none;font-weight:600;display:inline-block;">
+      Activate my account
+    </a>
+  </p>
+  <p style="font-size:12px;color:#6b7280;">
+    This link expires in 72 hours. If you did not expect this invitation you can
+    safely ignore this email.
+  </p>
+  <p>
+   — The {organization_name} Team
+  </p>
+</body>
+</html>"""
+
+    resend.Emails.send({
+        "from": from_address,
+        "to": [to_email],
+        "subject": f"You have been invited to join {organization_name}",
+        "text": plain,
+        "html": html,
+    })
+
+    logger.info("Invitation email sent to %s via Resend", to_email)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,6 @@ psycopg2-binary>=2.9,<3
 pydantic>=2,<3
 python-dotenv>=1,<2
 PyJWT>=2.8,<3
+resend>=2,<3
 SQLAlchemy>=2,<3
 uvicorn>=0.27,<1

--- a/frontend/app/invite/page.tsx
+++ b/frontend/app/invite/page.tsx
@@ -16,16 +16,15 @@ function InviteForm() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
 
-  const [state, setState] = useState<PageState>({ kind: "loading" });
+  const [state, setState] = useState<PageState>(() =>
+    token ? { kind: "loading" } : { kind: "invalid", reason: "No invitation token found in the URL." }
+  );
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [fieldError, setFieldError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token) {
-      setState({ kind: "invalid", reason: "No invitation token found in the URL." });
-      return;
-    }
+    if (!token) return;
 
     verifyInvitation(token)
       .then((info) => setState({ kind: "ready", info }))

--- a/frontend/app/invite/page.tsx
+++ b/frontend/app/invite/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { FormEvent, Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { acceptInvitation, verifyInvitation, type VerifyInvitationResult } from "@/lib/api";
+
+type PageState =
+  | { kind: "loading" }
+  | { kind: "invalid"; reason: string }
+  | { kind: "ready"; info: VerifyInvitationResult }
+  | { kind: "submitting"; info: VerifyInvitationResult }
+  | { kind: "success"; email: string };
+
+function InviteForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [state, setState] = useState<PageState>({ kind: "loading" });
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setState({ kind: "invalid", reason: "No invitation token found in the URL." });
+      return;
+    }
+
+    verifyInvitation(token)
+      .then((info) => setState({ kind: "ready", info }))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : "Invalid or expired invitation.";
+        setState({ kind: "invalid", reason: message });
+      });
+  }, [token]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (state.kind !== "ready") return;
+
+    if (password !== confirmPassword) {
+      setFieldError("Passwords do not match.");
+      return;
+    }
+
+    setFieldError(null);
+    setState({ kind: "submitting", info: state.info });
+
+    try {
+      const result = await acceptInvitation(token, password);
+      setState({ kind: "success", email: result.email });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to accept invitation.";
+      setState({ kind: "ready", info: (state as { kind: "submitting"; info: VerifyInvitationResult }).info });
+      setFieldError(message);
+    }
+  };
+
+  if (state.kind === "loading") {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-gray-600">Verifying invitation…</p>
+      </div>
+    );
+  }
+
+  if (state.kind === "invalid") {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-sm p-8 text-center">
+          <h1 className="text-xl font-semibold text-gray-900 mb-3">Invalid Invitation</h1>
+          <p className="text-sm text-gray-600">{state.reason}</p>
+          <button
+            type="button"
+            onClick={() => router.push("/")}
+            className="mt-6 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
+          >
+            Go to sign in
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.kind === "success") {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-sm p-8 text-center">
+          <h1 className="text-xl font-semibold text-gray-900 mb-3">Account activated</h1>
+          <p className="text-sm text-gray-600">
+            Your account for <span className="font-medium">{state.email}</span> is ready. You can now sign in.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.push("/")}
+            className="mt-6 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
+          >
+            Go to sign in
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const info = state.kind === "submitting" ? state.info : state.info;
+  const isSubmitting = state.kind === "submitting";
+
+  const expiresAt = new Date(info.expires_at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-sm p-8">
+        <h1 className="text-xl font-semibold text-gray-900 mb-1">Set up your account</h1>
+        <p className="text-sm text-gray-500 mb-6">Invitation expires {expiresAt}</p>
+
+        <div className="mb-6 space-y-1 text-sm">
+          <p>
+            <span className="text-gray-500">Name: </span>
+            <span className="text-gray-900 font-medium">{info.full_name}</span>
+          </p>
+          <p>
+            <span className="text-gray-500">Email: </span>
+            <span className="text-gray-900 font-medium">{info.email}</span>
+          </p>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">New password</label>
+            <input
+              required
+              type="password"
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-red-500"
+              placeholder="At least 8 characters"
+              disabled={isSubmitting}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Confirm password</label>
+            <input
+              required
+              type="password"
+              minLength={8}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-red-500"
+              placeholder="Re-enter password"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {fieldError ? (
+            <p className="text-sm text-red-600">{fieldError}</p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            {isSubmitting ? "Activating account…" : "Activate account"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function InvitePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+          <p className="text-gray-600">Loading…</p>
+        </div>
+      }
+    >
+      <InviteForm />
+    </Suspense>
+  );
+}

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -205,6 +205,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
   const [pendingOrgCreate, setPendingOrgCreate] = useState<AdminCreateOrganizationInput | null>(null);
   const [pendingUserCreate, setPendingUserCreate] = useState<AdminCreateUserInput | null>(null);
   const [invitationUrl, setInvitationUrl] = useState<string | null>(null);
+  const [invitedUserName, setInvitedUserName] = useState<string | null>(null);
   const [inviteEmailDraft, setInviteEmailDraft] = useState('');
   const [inviteEmailStatus, setInviteEmailStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
   const [inviteEmailError, setInviteEmailError] = useState<string | null>(null);
@@ -296,7 +297,11 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
 
   const handleCreateUser = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setPendingUserCreate({ ...userForm });
+    const payload = { ...userForm };
+    if (payload.status === 'invited') {
+      delete payload.password;
+    }
+    setPendingUserCreate(payload);
   };
 
   const executeCreateUser = async () => {
@@ -308,6 +313,8 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
         organization_id: previous.organization_id,
       }));
       if (created.invitation_url) {
+        setInvitedUserName(`${pendingUserCreate.first_name} ${pendingUserCreate.last_name}`.trim());
+        setInviteEmailDraft(pendingUserCreate.email);
         setInvitationUrl(created.invitation_url);
       } else {
         setFlash({ kind: 'success', message: `User created: ${created.full_name}` });
@@ -737,18 +744,24 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
               />
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Temporary Password</label>
-              <input
-                required
-                minLength={8}
-                type="password"
-                placeholder="Min. 8 characters"
-                value={userForm.password}
-                onChange={(event) => setUserForm((previous) => ({ ...previous, password: event.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
-              />
-            </div>
+            {userForm.status !== 'invited' ? (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Temporary Password</label>
+                <input
+                  required
+                  minLength={8}
+                  type="password"
+                  placeholder="Min. 8 characters"
+                  value={userForm.password}
+                  onChange={(event) => setUserForm((previous) => ({ ...previous, password: event.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
+                />
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">
+                No password needed — the user will set one via the invitation link.
+              </p>
+            )}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
               <select
@@ -1062,7 +1075,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
             { label: 'Email', value: pendingUserCreate.email },
             { label: 'Role', value: pendingUserCreate.role_slug ?? '' },
             { label: 'Status', value: pendingUserCreate.status ?? '' },
-            { label: 'Temporary Password', value: '••••••••' },
+            ...(pendingUserCreate.status !== 'invited' ? [{ label: 'Temporary Password', value: '••••••••' }] : []),
           ]}
           onConfirm={() => void executeCreateUser()}
           onClose={() => setPendingUserCreate(null)}
@@ -1076,7 +1089,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
               <h2 className="text-lg font-semibold text-gray-900">Invitation link ready</h2>
               <button
                 type="button"
-                onClick={() => { setInvitationUrl(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
+                onClick={() => { setInvitationUrl(null); setInvitedUserName(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
                 className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors"
               >
                 <X className="w-4 h-4" />
@@ -1119,9 +1132,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                       if (!inviteEmailDraft || !invitationUrl) return;
                       setInviteEmailStatus('sending');
                       setInviteEmailError(null);
-                      const recipientName = pendingUserCreate
-                        ? `${pendingUserCreate.first_name} ${pendingUserCreate.last_name}`.trim()
-                        : inviteEmailDraft;
+                      const recipientName = invitedUserName ?? inviteEmailDraft;
                       const orgName = organizations.find((o) => o.id === userForm.organization_id)?.name;
                       void sendInvitationEmail(inviteEmailDraft, recipientName, invitationUrl, orgName)
                         .then(() => setInviteEmailStatus('sent'))
@@ -1146,7 +1157,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
             <div className="px-6 py-4 border-t border-gray-200 flex justify-end">
               <button
                 type="button"
-                onClick={() => { setInvitationUrl(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
+                onClick={() => { setInvitationUrl(null); setInvitedUserName(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
                 className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
               >
                 Done

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -1122,7 +1122,8 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                       const recipientName = pendingUserCreate
                         ? `${pendingUserCreate.first_name} ${pendingUserCreate.last_name}`.trim()
                         : inviteEmailDraft;
-                      void sendInvitationEmail(inviteEmailDraft, recipientName, invitationUrl)
+                      const orgName = organizations.find((o) => o.id === userForm.organization_id)?.name;
+                      void sendInvitationEmail(inviteEmailDraft, recipientName, invitationUrl, orgName)
                         .then(() => setInviteEmailStatus('sent'))
                         .catch((err: unknown) => {
                           setInviteEmailStatus('idle');

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -203,6 +203,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
   const closeConfirm = () => setConfirmDialog(null);
   const [pendingOrgCreate, setPendingOrgCreate] = useState<AdminCreateOrganizationInput | null>(null);
   const [pendingUserCreate, setPendingUserCreate] = useState<AdminCreateUserInput | null>(null);
+  const [invitationUrl, setInvitationUrl] = useState<string | null>(null);
   const [userNameFilter, setUserNameFilter] = useState('');
   const [userRoleFilter, setUserRoleFilter] = useState('');
 
@@ -302,7 +303,11 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
         ...initialUserForm,
         organization_id: previous.organization_id,
       }));
-      setFlash({ kind: 'success', message: `User created: ${created.full_name}` });
+      if (created.invitation_url) {
+        setInvitationUrl(created.invitation_url);
+      } else {
+        setFlash({ kind: 'success', message: `User created: ${created.full_name}` });
+      }
       await loadAdminData(true);
     } catch (createError) {
       setFlash({
@@ -871,7 +876,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
               <button
                 type="button"
                 onClick={() => { setUserNameFilter(''); setUserRoleFilter(''); }}
-                className="bg-red-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm hover:bg-gray-50 transition-colors text-amber-50 hover:text-amber-700"
+                className="bg-red-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm hover:bg-gray-50 transition-colors"
               >
                 Reset filters
               </button>
@@ -1054,6 +1059,51 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
           onConfirm={() => void executeCreateUser()}
           onClose={() => setPendingUserCreate(null)}
         />
+      ) : null}
+
+      {invitationUrl ? (
+        <div className="fixed inset-0 z-[80] bg-black/60 backdrop-blur-sm flex items-center justify-center p-4">
+          <div className="w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-xl">
+            <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Invitation link ready</h2>
+              <button
+                type="button"
+                onClick={() => setInvitationUrl(null)}
+                className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="px-6 py-5">
+              <p className="text-sm text-gray-600 mb-3">
+                Share this link with the user so they can set their password and activate their account. It expires in 72 hours.
+              </p>
+              <div className="flex items-center gap-2">
+                <input
+                  readOnly
+                  value={invitationUrl}
+                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-xs text-gray-800 bg-gray-50 truncate"
+                />
+                <button
+                  type="button"
+                  onClick={() => void navigator.clipboard.writeText(invitationUrl)}
+                  className="border border-gray-300 px-3 py-2 rounded-lg text-xs hover:bg-gray-100 transition-colors"
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+            <div className="px-6 py-4 border-t border-gray-200 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setInvitationUrl(null)}
+                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -1047,8 +1047,8 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
             { label: 'First Name', value: pendingUserCreate.first_name },
             { label: 'Last Name', value: pendingUserCreate.last_name },
             { label: 'Email', value: pendingUserCreate.email },
-            { label: 'Role', value: pendingUserCreate.role_slug ?? "" },
-            { label: 'Status', value: pendingUserCreate.status  ?? "" },
+            { label: 'Role', value: pendingUserCreate.role_slug ?? '' },
+            { label: 'Status', value: pendingUserCreate.status ?? '' },
             { label: 'Temporary Password', value: '••••••••' },
           ]}
           onConfirm={() => void executeCreateUser()}

--- a/frontend/figma/components/AdminDashboard.tsx
+++ b/frontend/figma/components/AdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
   getAdminUsers,
   removeAdminRole,
   revokeAdminInvitation,
+  sendInvitationEmail,
 } from '@/lib/api';
 
 type ConfirmDialogState = {
@@ -204,6 +205,9 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
   const [pendingOrgCreate, setPendingOrgCreate] = useState<AdminCreateOrganizationInput | null>(null);
   const [pendingUserCreate, setPendingUserCreate] = useState<AdminCreateUserInput | null>(null);
   const [invitationUrl, setInvitationUrl] = useState<string | null>(null);
+  const [inviteEmailDraft, setInviteEmailDraft] = useState('');
+  const [inviteEmailStatus, setInviteEmailStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+  const [inviteEmailError, setInviteEmailError] = useState<string | null>(null);
   const [userNameFilter, setUserNameFilter] = useState('');
   const [userRoleFilter, setUserRoleFilter] = useState('');
 
@@ -704,6 +708,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                 <input
                   required
                   type="text"
+                  placeholder="First"
                   value={userForm.first_name}
                   onChange={(event) => setUserForm((previous) => ({ ...previous, first_name: event.target.value }))}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
@@ -714,6 +719,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                 <input
                   required
                   type="text"
+                  placeholder="Last"
                   value={userForm.last_name}
                   onChange={(event) => setUserForm((previous) => ({ ...previous, last_name: event.target.value }))}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
@@ -725,6 +731,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
               <input
                 required
                 type="email"
+                placeholder="first@example.com"
                 value={userForm.email}
                 onChange={(event) => setUserForm((previous) => ({ ...previous, email: event.target.value }))}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
@@ -736,6 +743,7 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
                 required
                 minLength={8}
                 type="password"
+                placeholder="Min. 8 characters"
                 value={userForm.password}
                 onChange={(event) => setUserForm((previous) => ({ ...previous, password: event.target.value }))}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500"
@@ -1068,35 +1076,76 @@ export function AdminDashboard({ currentUser }: AdminDashboardProps) {
               <h2 className="text-lg font-semibold text-gray-900">Invitation link ready</h2>
               <button
                 type="button"
-                onClick={() => setInvitationUrl(null)}
+                onClick={() => { setInvitationUrl(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
                 className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors"
               >
                 <X className="w-4 h-4" />
               </button>
             </div>
-            <div className="px-6 py-5">
-              <p className="text-sm text-gray-600 mb-3">
-                Share this link with the user so they can set their password and activate their account. It expires in 72 hours.
-              </p>
-              <div className="flex items-center gap-2">
-                <input
-                  readOnly
-                  value={invitationUrl}
-                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-xs text-gray-800 bg-gray-50 truncate"
-                />
-                <button
-                  type="button"
-                  onClick={() => void navigator.clipboard.writeText(invitationUrl)}
-                  className="border border-gray-300 px-3 py-2 rounded-lg text-xs hover:bg-gray-100 transition-colors"
-                >
-                  Copy
-                </button>
+            <div className="px-6 py-5 space-y-4">
+              <div>
+                <p className="text-sm text-gray-600 mb-2">
+                  Share this link with the user so they can set their password and activate their account. It expires in 72 hours.
+                </p>
+                <div className="flex items-center gap-2">
+                  <input
+                    readOnly
+                    value={invitationUrl}
+                    className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-xs text-gray-800 bg-gray-50 truncate"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void navigator.clipboard.writeText(invitationUrl)}
+                    className="border border-gray-300 px-3 py-2 rounded-lg text-xs hover:bg-gray-100 transition-colors"
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+              <div className="border-t border-gray-100 pt-4">
+                <p className="text-sm font-medium text-gray-700 mb-2">Send via email</p>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="email"
+                    placeholder="recipient@example.com"
+                    value={inviteEmailDraft}
+                    onChange={(e) => { setInviteEmailDraft(e.target.value); setInviteEmailError(null); }}
+                    className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+                  />
+                  <button
+                    type="button"
+                    disabled={!inviteEmailDraft || inviteEmailStatus === 'sending' || inviteEmailStatus === 'sent'}
+                    onClick={() => {
+                      if (!inviteEmailDraft || !invitationUrl) return;
+                      setInviteEmailStatus('sending');
+                      setInviteEmailError(null);
+                      const recipientName = pendingUserCreate
+                        ? `${pendingUserCreate.first_name} ${pendingUserCreate.last_name}`.trim()
+                        : inviteEmailDraft;
+                      void sendInvitationEmail(inviteEmailDraft, recipientName, invitationUrl)
+                        .then(() => setInviteEmailStatus('sent'))
+                        .catch((err: unknown) => {
+                          setInviteEmailStatus('idle');
+                          setInviteEmailError(err instanceof Error ? err.message : 'Failed to send email.');
+                        });
+                    }}
+                    className="px-3 py-2 rounded-lg text-sm font-medium bg-red-600 hover:bg-red-700 disabled:bg-red-300 text-white transition-colors"
+                  >
+                    {inviteEmailStatus === 'sending' ? 'Sending…' : inviteEmailStatus === 'sent' ? 'Sent ✓' : 'Send'}
+                  </button>
+                </div>
+                {inviteEmailStatus === 'sent' && (
+                  <p className="mt-1.5 text-xs text-green-600">Email sent successfully.</p>
+                )}
+                {inviteEmailError ? (
+                  <p className="mt-1.5 text-xs text-red-600">{inviteEmailError}</p>
+                ) : null}
               </div>
             </div>
             <div className="px-6 py-4 border-t border-gray-200 flex justify-end">
               <button
                 type="button"
-                onClick={() => setInvitationUrl(null)}
+                onClick={() => { setInvitationUrl(null); setInviteEmailDraft(''); setInviteEmailStatus('idle'); setInviteEmailError(null); }}
                 className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
               >
                 Done

--- a/frontend/figma/storybook/fixtures.ts
+++ b/frontend/figma/storybook/fixtures.ts
@@ -654,3 +654,11 @@ export const mockAdminOverview: AdminOverview = {
     created_at: entry.created_at,
   })),
 };
+
+export const mockAdminOperations: AdminOperations = {
+  organization_id: organizationId,
+  unassigned_cases: [],
+  aging_cases: [],
+  lawyer_workload: [],
+  pending_invitations: [],
+};

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -174,7 +174,7 @@ export type AdminCreateUserInput = {
   email: string;
   first_name: string;
   last_name: string;
-  password: string;
+  password?: string;
   status?: string;
   role_slug?: string;
 };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -905,6 +905,21 @@ export async function assignAdminCaseLawyer(
   });
 }
 
+export async function sendInvitationEmail(
+  toEmail: string,
+  recipientName: string,
+  invitationUrl: string,
+): Promise<void> {
+  return requestVoid('/api/v1/admin/send-invitation-email', {
+    method: 'POST',
+    body: JSON.stringify({
+      to_email: toEmail,
+      recipient_name: recipientName,
+      invitation_url: invitationUrl,
+    }),
+  });
+}
+
 export async function revokeAdminInvitation(invitationId: string): Promise<void> {
   return requestVoid(`/api/v1/admin/invitations/${encodeURIComponent(invitationId)}/revoke`, {
     method: 'POST',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -179,6 +179,23 @@ export type AdminCreateUserInput = {
   role_slug?: string;
 };
 
+export type AdminCreateUserResult = UserListItem & {
+  invitation_url: string | null;
+};
+
+export type VerifyInvitationResult = {
+  email: string;
+  full_name: string;
+  organization_id: string;
+  expires_at: string;
+};
+
+export type AcceptInvitationResult = {
+  message: string;
+  email: string;
+  organization_id: string;
+};
+
 export type AdminOperations = {
   organization_id: string;
   unassigned_cases: Array<{
@@ -836,10 +853,23 @@ export async function deleteAdminOrganization(organizationId: string): Promise<v
   });
 }
 
-export async function createAdminUser(input: AdminCreateUserInput): Promise<UserListItem> {
-  return requestJson<UserListItem>('/api/v1/admin/users', {
+export async function createAdminUser(input: AdminCreateUserInput): Promise<AdminCreateUserResult> {
+  return requestJson<AdminCreateUserResult>('/api/v1/admin/users', {
     method: 'POST',
     body: JSON.stringify(input),
+  });
+}
+
+export async function verifyInvitation(token: string): Promise<VerifyInvitationResult> {
+  return requestJson<VerifyInvitationResult>(
+    `/api/v1/auth/verify-invitation?token=${encodeURIComponent(token)}`
+  );
+}
+
+export async function acceptInvitation(token: string, password: string): Promise<AcceptInvitationResult> {
+  return requestJson<AcceptInvitationResult>('/api/v1/auth/accept-invitation', {
+    method: 'POST',
+    body: JSON.stringify({ token, password }),
   });
 }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -909,6 +909,7 @@ export async function sendInvitationEmail(
   toEmail: string,
   recipientName: string,
   invitationUrl: string,
+  organizationName?: string,
 ): Promise<void> {
   return requestVoid('/api/v1/admin/send-invitation-email', {
     method: 'POST',
@@ -916,6 +917,7 @@ export async function sendInvitationEmail(
       to_email: toEmail,
       recipient_name: recipientName,
       invitation_url: invitationUrl,
+      organization_name: organizationName,
     }),
   });
 }


### PR DESCRIPTION
# Pull Request

Made changes to the backend to allow admin (specifically only admin, as lawyers ability to send invites is in another PR for cleanliness sake) to invite users, and upon clicking the link and resetting their password, the user's account is activated and they are able to normally login. 

## 📝 Description
## 🔗 Linked Issue
Closes #

## ✅ Checklist
- [ ] My code follows the project's style guidelines.
- [ ] I have linked the relevant issue using "Closes #X".
- [ ] I have requested exactly 1 reviewer.
- [ ] I have verified that the build passes locally.

## 📸 Screenshots (if applicable)

After creating a new user, and set the status to "invited", you get the following pop-up:
<img width="325" height="279" alt="image" src="https://github.com/user-attachments/assets/5881d3ea-7647-4d59-a536-7925f003ac00" />
<img width="1458" height="228" alt="image" src="https://github.com/user-attachments/assets/6d8dc5d9-b4af-4eda-8f50-58fcc6f102cd" />


Email received in client inbox (it shows test18 because I had to make a few updates - email was previously addressed to the email address not the user's name):
<img width="1188" height="430" alt="image" src="https://github.com/user-attachments/assets/55154a9d-0770-4b10-ac32-c49eff72e5b4" />

Upon clicking the link, the invited user is able to set their account password:
<img width="1083" height="711" alt="image" src="https://github.com/user-attachments/assets/9b075f8e-e7f4-4b73-9c76-a2a3645a51fd" />

Showing account is activated after they replace their password:
<img width="547" height="260" alt="image" src="https://github.com/user-attachments/assets/2a20790d-9566-4d10-a6f2-c3bde35455a9" />

The account is now active:
<img width="1479" height="218" alt="image" src="https://github.com/user-attachments/assets/9a9cc06e-4b08-4623-a2b3-e2cc28257ff3" />


