### PR TITLE
Client/ Lawyer status updates

### DIFF
--- a/backend/app/api/routes/cases.py
+++ b/backend/app/api/routes/cases.py
@@ -76,12 +76,10 @@ ALLOWED_PORTAL_ACCESS = {"full_access", "limited_access", "read_only", "disabled
 ALLOWED_DOCUMENT_UPLOAD = {"enabled", "disabled"}
 ALLOWED_MESSAGING = {"two_way", "one_way", "disabled"}
 ALLOWED_DOCUMENT_STATUSES = {
-    "pending",
-    "received",
-    "under_review",
+    "requested",
+    "received_under_review",
     "approved",
     "rejected",
-    "needs_revision",
     "expired",
     "not_requested",
 }
@@ -170,6 +168,17 @@ def _normalize_token(value: str) -> str:
     return value.strip().lower().replace(" ", "_")
 
 
+def _normalize_document_status_value(value: Any) -> str:
+    normalized = _normalize_token(str(value or ""))
+    if normalized == "pending":
+        return "requested"
+    if normalized in {"received", "under_review", "under-review", "received_under_review"}:
+        return "received_under_review"
+    if normalized == "needs_revision":
+        return "rejected"
+    return normalized
+
+
 def _generate_case_number(db: Session, organization_id: UUID) -> str:
     year = date.today().year
     prefix_like = f"C-{year}-%"
@@ -249,10 +258,24 @@ def _normalized_document_status_overrides(raw: Any) -> dict[str, str]:
     normalized: dict[str, str] = {}
     for key, value in raw.items():
         doc_id = str(key).strip()
-        status_value = _normalize_token(str(value)) if value is not None else ""
+        status_value = _normalize_document_status_value(value)
         if not doc_id or status_value not in ALLOWED_DOCUMENT_STATUSES:
             continue
         normalized[doc_id] = status_value
+    return normalized
+
+
+def _normalized_document_rejection_notes(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        doc_id = str(key).strip()
+        note = str(value or "").strip()
+        if not doc_id or not note:
+            continue
+        normalized[doc_id] = note[:2000]
     return normalized
 
 
@@ -320,7 +343,7 @@ def _normalized_custom_documents(raw: Any) -> list[dict[str, Any]]:
             continue
 
         suite_id = str(doc.get("suite_id") or "").strip() or None
-        status_value = _normalize_token(str(doc.get("status") or ""))
+        status_value = _normalize_document_status_value(doc.get("status") or "")
         status = status_value if status_value in ALLOWED_DOCUMENT_STATUSES else None
 
         normalized.append(
@@ -401,6 +424,9 @@ def _resolve_document_slot(*, case: Case, document_id: str, db: Session) -> dict
     custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
     custom_documents = _normalized_custom_documents(custom_fields.get("custom_documents"))
     upload_bindings = _normalized_document_upload_bindings(custom_fields.get("document_upload_bindings"))
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
 
     try:
         document_uuid = UUID(document_id)
@@ -1408,6 +1434,9 @@ def get_case_workspace_by_number(
         custom_fields.get("hidden_document_ids")
     )
     custom_documents = _normalized_custom_documents(custom_fields.get("custom_documents"))
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
     portal_permissions_payload = _normalized_portal_permissions(custom_fields.get("portal_permissions"))
     is_client_portal_view = (
         "client" in auth.roles
@@ -1447,7 +1476,7 @@ def get_case_workspace_by_number(
                 dt.instructions,
                 dt.is_required,
                 cd.id AS latest_case_document_id,
-                COALESCE(cd.status, CASE WHEN dt.is_required THEN 'pending' ELSE 'not_requested' END) AS doc_status,
+                COALESCE(cd.status, CASE WHEN dt.is_required THEN 'requested' ELSE 'not_requested' END) AS doc_status,
                 cd.uploaded_at,
                 cd.expiry_date,
                 cd.file_name,
@@ -1510,11 +1539,15 @@ def get_case_workspace_by_number(
                     id=template_id_str,
                     name=document_name_overrides.get(template_id_str, document_row["template_name"]),
                     required=bool(document_row["is_required"]),
-                    status=document_status_overrides.get(template_id_str, document_row["doc_status"]),
+                    status=document_status_overrides.get(
+                        template_id_str,
+                        _normalize_document_status_value(document_row["doc_status"]),
+                    ),
                     due_date=document_row["expiry_date"],
                     uploaded_at=document_row["uploaded_at"],
                     instructions=document_row["instructions"],
                     client_note=document_row.get("client_note"),
+                    rejection_note=rejection_notes.get(template_id_str),
                     file_name=document_row["file_name"],
                     latest_case_document_id=(
                         str(document_row["latest_case_document_id"])
@@ -1590,12 +1623,15 @@ def get_case_workspace_by_number(
                 required=False,
                 status=document_status_overrides.get(
                     custom_document_id,
-                    custom_document_row["status"] or "received",
+                    _normalize_document_status_value(
+                        custom_document_row["status"] or "received_under_review"
+                    ),
                 ),
                 due_date=custom_document_row["expiry_date"],
                 uploaded_at=custom_document_row["uploaded_at"],
                 instructions="",
                 client_note=custom_document_row.get("client_note"),
+                rejection_note=rejection_notes.get(custom_document_id),
                 file_name=custom_document_row["file_name"],
                 latest_case_document_id=custom_document_id,
                 can_download=True,
@@ -1636,9 +1672,15 @@ def get_case_workspace_by_number(
                 "documents": [],
             }
 
-        default_status = custom_document["status"] or ("pending" if custom_document["required"] else "not_requested")
+        default_status = _normalize_document_status_value(
+            custom_document["status"] or ("requested" if custom_document["required"] else "not_requested")
+        )
         bound_case_document = bound_case_document_rows.get(upload_bindings.get(custom_document_id, ""))
-        bound_status = bound_case_document["status"] if bound_case_document else None
+        bound_status = (
+            _normalize_document_status_value(bound_case_document["status"])
+            if bound_case_document
+            else None
+        )
         bound_uploaded_at = bound_case_document["uploaded_at"] if bound_case_document else None
         bound_file_name = bound_case_document["file_name"] if bound_case_document else None
         bound_client_note = bound_case_document.get("client_note") if bound_case_document else None
@@ -1652,6 +1694,7 @@ def get_case_workspace_by_number(
                 uploaded_at=bound_uploaded_at,
                 instructions=custom_document["instructions"],
                 client_note=bound_client_note,
+                rejection_note=rejection_notes.get(custom_document_id),
                 file_name=bound_file_name,
                 latest_case_document_id=str(bound_case_document["id"]) if bound_case_document else None,
                 can_download=bound_case_document is not None,
@@ -2083,7 +2126,7 @@ def create_case_custom_document(
     custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
     custom_documents = _normalized_custom_documents(custom_fields.get("custom_documents"))
     new_document_id = str(uuid4())
-    default_status = "pending" if payload.required else "not_requested"
+    default_status = "requested" if payload.required else "not_requested"
     new_document = {
         "id": new_document_id,
         "name": name,
@@ -2339,9 +2382,15 @@ def update_case_document_status(
 ) -> CaseDocumentStatusUpdateResponse:
     case = _get_case_with_write_access(case_number=case_number, auth=auth, db=db)
 
-    normalized_status = _normalize_token(payload.status)
+    normalized_status = _normalize_document_status_value(payload.status)
     if normalized_status not in ALLOWED_DOCUMENT_STATUSES:
         raise HTTPException(status_code=400, detail="Invalid document status")
+
+    normalized_rejection_note = (payload.rejection_note or "").strip() or None
+    if normalized_rejection_note and len(normalized_rejection_note) > 2000:
+        raise HTTPException(status_code=400, detail="Rejection note must be 2000 characters or fewer")
+    if normalized_status == "rejected" and not normalized_rejection_note:
+        raise HTTPException(status_code=400, detail="Rejection note is required when rejecting a document")
 
     try:
         document_uuid = UUID(document_id)
@@ -2399,6 +2448,9 @@ def update_case_document_status(
     status_overrides = _normalized_document_status_overrides(
         custom_fields.get("document_status_overrides")
     )
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
 
     if custom_document_exists:
         for custom_document in custom_documents:
@@ -2406,14 +2458,27 @@ def update_case_document_status(
                 custom_document["status"] = normalized_status
                 break
         status_overrides.pop(str(document_uuid), None)
+        if normalized_status == "rejected" and normalized_rejection_note:
+            rejection_notes[str(document_uuid)] = normalized_rejection_note
+        else:
+            rejection_notes.pop(str(document_uuid), None)
         case.custom_fields = {
             **custom_fields,
             "custom_documents": custom_documents,
             "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
         }
     else:
         status_overrides[str(document_uuid)] = normalized_status
-        case.custom_fields = {**custom_fields, "document_status_overrides": status_overrides}
+        if normalized_status == "rejected" and normalized_rejection_note:
+            rejection_notes[str(document_uuid)] = normalized_rejection_note
+        else:
+            rejection_notes.pop(str(document_uuid), None)
+        case.custom_fields = {
+            **custom_fields,
+            "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
+        }
 
     db.add(case)
     db.commit()
@@ -2421,6 +2486,7 @@ def update_case_document_status(
     return CaseDocumentStatusUpdateResponse(
         document_id=str(document_uuid),
         status=normalized_status,
+        rejection_note=normalized_rejection_note if normalized_status == "rejected" else None,
     )
 
 
@@ -2554,7 +2620,7 @@ def complete_case_document_upload(
                 :file_hash,
                 :version,
                 CAST(:previous_version_id AS uuid),
-                'received',
+                'received_under_review',
                 :issue_date,
                 :expiry_date,
                 :uploaded_by
@@ -2588,11 +2654,16 @@ def complete_case_document_upload(
         upload_bindings = _normalized_document_upload_bindings(custom_fields.get("document_upload_bindings"))
         upload_bindings[slot["logical_document_id"]] = str(insert_result["id"])
         status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
+        rejection_notes = _normalized_document_rejection_notes(
+            custom_fields.get("document_rejection_notes")
+        )
         status_overrides.pop(slot["logical_document_id"], None)
+        rejection_notes.pop(slot["logical_document_id"], None)
         case.custom_fields = {
             **custom_fields,
             "document_upload_bindings": upload_bindings,
             "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
         }
         db.add(case)
 
@@ -2628,11 +2699,12 @@ def complete_case_document_upload(
         id=slot["logical_document_id"],
         name=slot["name"],
         required=bool(slot["required"]),
-        status="received",
+        status="received_under_review",
         due_date=payload.expiry_date,
         uploaded_at=insert_result["uploaded_at"],
         instructions=slot["instructions"],
         client_note=normalized_client_note,
+        rejection_note=None,
         file_name=actual_file_name,
         latest_case_document_id=str(insert_result["id"]),
         can_download=True,

--- a/backend/app/api/routes/cases.py
+++ b/backend/app/api/routes/cases.py
@@ -2649,23 +2649,31 @@ def complete_case_document_upload(
     if insert_result is None:
         raise HTTPException(status_code=500, detail="Failed to record uploaded document")
 
+    custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
+    status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
+    status_overrides.pop(slot["logical_document_id"], None)
+    rejection_notes.pop(slot["logical_document_id"], None)
+
     if slot["kind"] == "custom_request":
-        custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
         upload_bindings = _normalized_document_upload_bindings(custom_fields.get("document_upload_bindings"))
         upload_bindings[slot["logical_document_id"]] = str(insert_result["id"])
-        status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
-        rejection_notes = _normalized_document_rejection_notes(
-            custom_fields.get("document_rejection_notes")
-        )
-        status_overrides.pop(slot["logical_document_id"], None)
-        rejection_notes.pop(slot["logical_document_id"], None)
         case.custom_fields = {
             **custom_fields,
             "document_upload_bindings": upload_bindings,
             "document_status_overrides": status_overrides,
             "document_rejection_notes": rejection_notes,
         }
-        db.add(case)
+    else:
+        case.custom_fields = {
+            **custom_fields,
+            "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
+        }
+
+    db.add(case)
 
     log_activity(
         db,

--- a/backend/app/schemas/case.py
+++ b/backend/app/schemas/case.py
@@ -83,6 +83,7 @@ class CaseWorkspaceDocument(BaseModel):
     uploaded_at: Optional[datetime]
     instructions: Optional[str]
     client_note: Optional[str] = None
+    rejection_note: Optional[str] = None
     file_name: Optional[str] = None
     latest_case_document_id: Optional[str] = None
     can_download: bool = False
@@ -177,11 +178,13 @@ class CaseCustomDocumentSuiteCreateRequest(BaseModel):
 
 class CaseDocumentStatusUpdateRequest(BaseModel):
     status: str
+    rejection_note: Optional[str] = None
 
 
 class CaseDocumentStatusUpdateResponse(BaseModel):
     document_id: str
     status: str
+    rejection_note: Optional[str] = None
 
 
 class CaseDocumentUploadInitiateRequest(BaseModel):

--- a/backend/tests/api/routes/test_cases.py
+++ b/backend/tests/api/routes/test_cases.py
@@ -41,7 +41,7 @@ def test_case_helper_normalizers_and_sanitizers():
             'required': True,
             'due_date': None,
             'instructions': None,
-            'status': 'under_review',
+            'status': 'received_under_review',
         }
     ]
     assert cases._sanitize_file_name(' My File?.pdf ') == 'My_File_.pdf'
@@ -514,7 +514,7 @@ def test_update_case_document_status_updates_custom_document(monkeypatch, make_a
         id=uuid4(),
         organization_id=auth.organization_id,
         case_type='Express Entry',
-        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'pending'}]},
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'requested'}]},
     )
     db = MagicMock()
     db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
@@ -530,6 +530,61 @@ def test_update_case_document_status_updates_custom_document(monkeypatch, make_a
 
     assert result.status == 'approved'
     assert case.custom_fields['custom_documents'][0]['status'] == 'approved'
+
+
+def test_update_case_document_status_rejected_stores_rejection_note(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'requested'}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    result = cases.update_case_document_status(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentStatusUpdateRequest(
+            status='rejected',
+            rejection_note='Please upload the full passport page in color.'
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'rejected'
+    assert result.rejection_note == 'Please upload the full passport page in color.'
+    assert case.custom_fields['document_rejection_notes'][document_id] == 'Please upload the full passport page in color.'
+
+
+def test_update_case_document_status_rejected_requires_note(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'requested'}]},
+    )
+    db = MagicMock()
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    try:
+        cases.update_case_document_status(
+            case_number='C-2026-001',
+            document_id=document_id,
+            payload=CaseDocumentStatusUpdateRequest(status='rejected'),
+            auth=auth,
+            db=db,
+        )
+        assert False, 'Expected HTTPException'
+    except HTTPException as exc:
+        assert exc.status_code == 400
+        assert exc.detail == 'Rejection note is required when rejecting a document'
 
 
 def test_initiate_case_document_upload_returns_presigned_upload(monkeypatch, make_auth_context):
@@ -595,7 +650,7 @@ def test_complete_case_document_upload_records_upload(monkeypatch, make_auth_con
         db=db,
     )
 
-    assert result.status == 'received'
+    assert result.status == 'received_under_review'
     assert result.can_download is True
 
 

--- a/backend/tests/api/routes/test_cases.py
+++ b/backend/tests/api/routes/test_cases.py
@@ -654,6 +654,57 @@ def test_complete_case_document_upload_records_upload(monkeypatch, make_auth_con
     assert result.can_download is True
 
 
+def test_complete_case_document_upload_clears_rejection_state(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        client_id=auth.user_id,
+        custom_fields={
+            'document_status_overrides': {document_id: 'rejected'},
+            'document_rejection_notes': {document_id: 'Please upload all edges of the document.'},
+        },
+    )
+    slot = {
+        'kind': 'template',
+        'logical_document_id': document_id,
+        'template_id': document_id,
+        'name': 'Passport',
+        'required': True,
+        'instructions': 'Upload passport',
+        'previous_case_document_id': None,
+        'next_version': 2,
+    }
+    storage_key = f'org/{case.organization_id}/case/{case.id}/documents/{document_id}/uuid-passport.pdf'
+    db = MagicMock()
+    db.execute.return_value = FakeResult(rows=[{'id': uuid4(), 'uploaded_at': datetime.now(timezone.utc)}])
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, '_resolve_document_slot', lambda **kwargs: slot)
+    monkeypatch.setattr(cases, 'head_object', lambda **kwargs: {'ContentLength': 1024, 'ContentType': 'application/pdf'})
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+    monkeypatch.setattr(cases, 'log_document_access', lambda *args, **kwargs: None)
+
+    result = cases.complete_case_document_upload(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentUploadCompleteRequest(
+            storage_key=storage_key,
+            file_name='passport.pdf',
+            file_type='application/pdf',
+            file_size_bytes=1024,
+        ),
+        request=row(client=row(host='127.0.0.1'), headers={'user-agent': 'pytest'}),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'received_under_review'
+    assert result.rejection_note is None
+    assert case.custom_fields['document_status_overrides'] == {}
+    assert case.custom_fields['document_rejection_notes'] == {}
+
+
 def test_get_case_document_download_url_returns_presigned_link(monkeypatch, make_auth_context):
     auth = make_auth_context(roles=['lawyer'])
     case = row(id=uuid4(), organization_id=auth.organization_id, custom_fields={})

--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -192,7 +192,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       approved: 0,
       received: 0,
       pending: 0,
-      needsRevision: 0,
+      rejected: 0,
     };
 
     if (!workspace) {
@@ -202,10 +202,10 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     for (const document of workspace.documents) {
       if (document.status === 'approved') {
         stats.approved += 1;
-      } else if (document.status === 'received') {
+      } else if (['received_under_review', 'received', 'under_review'].includes(document.status)) {
         stats.received += 1;
-      } else if (['needs_revision', 'needs-revision'].includes(document.status)) {
-        stats.needsRevision += 1;
+      } else if (['rejected', 'needs_revision', 'needs-revision'].includes(document.status)) {
+        stats.rejected += 1;
       } else {
         stats.pending += 1;
       }
@@ -268,7 +268,9 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       return 0;
     }
 
-    return workspace.documents.filter((document) => document.required && !['approved', 'received'].includes(document.status)).length;
+    return workspace.documents.filter(
+      (document) => document.required && !['approved', 'received_under_review'].includes(document.status)
+    ).length;
   }, [workspace]);
 
   const toggleSuite = (suiteId: string) => {
@@ -391,7 +393,9 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     }
 
     const pendingRequiredDocuments = workspace.documents.filter(
-      (document) => document.required && !['approved', 'received', 'completed'].includes(document.status)
+      (document) =>
+        document.required &&
+        !['approved', 'received_under_review', 'completed'].includes(document.status)
     );
     if (pendingRequiredDocuments.length === 0) {
       showNotice('info', 'No pending required documents for reminders.');
@@ -485,7 +489,11 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     }
   };
 
-  const handleUpdateDocumentStatus = async (documentId: string, status: CaseDocumentStatus) => {
+  const handleUpdateDocumentStatus = async (
+    documentId: string,
+    status: CaseDocumentStatus,
+    rejectionNote?: string | null
+  ) => {
     if (!workspace) {
       return;
     }
@@ -495,7 +503,8 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       const updated = await updateCaseDocumentStatus(
         workspace.case.case_number,
         documentId,
-        status
+        status,
+        rejectionNote
       );
 
       updateWorkspace((current) => ({
@@ -507,6 +516,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
               ? {
                   ...document,
                   status: updated.status,
+                  rejection_note: updated.rejection_note ?? null,
                 }
               : document
           ),
@@ -516,6 +526,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
             ? {
                 ...document,
                 status: updated.status,
+                rejection_note: updated.rejection_note ?? null,
               }
             : document
         ),

--- a/frontend/figma/components/ClientDashboard.tsx
+++ b/frontend/figma/components/ClientDashboard.tsx
@@ -132,7 +132,6 @@ export function ClientDashboard() {
               <MessagesPanel
                 allMessages={allMessages}
                 recentMessages={recentMessages}
-                canSendMessages={capabilities.canSendMessages}
               />
             ) : null}
             {capabilities.canViewMilestones ? (

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -72,7 +72,7 @@ export const Documents: Story = {
   render: () => (
     <DocumentsSection
       workspace={mockCaseWorkspace}
-      documentStats={{ approved: 1, received: 1, pending: 1, needsRevision: 1 }}
+      documentStats={{ approved: 1, received: 1, pending: 1, rejected: 1 }}
       expandedSuites={mockCaseWorkspace.document_suites.map((suite) => suite.id)}
       onToggleSuite={() => {}}
       onAddCustomDocument={async () => true}

--- a/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
@@ -5,11 +5,12 @@ import { ChevronDown, ChevronRight, Download, Edit2, FolderPlus, MessageSquare, 
 import type { CaseDocumentStatus, CaseWorkspace } from '@/lib/api';
 
 import { AddDocumentDialog } from '../dialogs/AddDocumentDialog';
+import { CaseConfigDialog } from '../dialogs/CaseConfigDialog';
 import { CreateSuiteDialog } from '../dialogs/CreateSuiteDialog';
 import { DeleteDocumentDialog } from '../dialogs/DeleteDocumentDialog';
 import { RenameDocumentDialog } from '../dialogs/RenameDocumentDialog';
 import type { DocumentStats, NewDocumentInput, NewDocumentSuiteInput } from '../types';
-import { formatDate, statusColor, titleize } from '../utils';
+import { documentStatusLabel, formatDate, statusColor } from '../utils';
 
 type DocumentsSectionProps = {
   workspace: CaseWorkspace;
@@ -28,7 +29,11 @@ type DocumentsSectionProps = {
   renamingDocumentId: string | null;
   onDownloadDocument: (documentId: string) => Promise<void>;
   downloadingDocumentId: string | null;
-  onUpdateDocumentStatus: (documentId: string, status: CaseDocumentStatus) => Promise<void>;
+  onUpdateDocumentStatus: (
+    documentId: string,
+    status: CaseDocumentStatus,
+    rejectionNote?: string | null
+  ) => Promise<void>;
   updatingDocumentId: string | null;
   onSendDocumentReminder: (documentId: string) => Promise<void>;
   sendingDocumentReminderId: string | null;
@@ -66,6 +71,9 @@ export function DocumentsSection({
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [noteTarget, setNoteTarget] = useState<{ name: string; note: string } | null>(null);
+  const [rejectionTarget, setRejectionTarget] = useState<{ id: string; name: string; note: string } | null>(null);
+  const [rejectionNoteValue, setRejectionNoteValue] = useState('');
+  const [rejectionNoteError, setRejectionNoteError] = useState<string | null>(null);
 
   const handleCreateSuite = async (input: NewDocumentSuiteInput): Promise<boolean> => {
     setIsCreatingSuite(true);
@@ -98,15 +106,36 @@ export function DocumentsSection({
   };
 
   const documentStatusOptions: Array<{ value: CaseDocumentStatus; label: string }> = [
-    { value: 'pending', label: 'Pending' },
-    { value: 'received', label: 'Received' },
-    { value: 'under_review', label: 'Under Review' },
+    { value: 'requested', label: 'Requested' },
+    { value: 'received_under_review', label: 'Received / Under Review' },
     { value: 'approved', label: 'Approved' },
-    { value: 'needs_revision', label: 'Needs Revision' },
     { value: 'rejected', label: 'Rejected' },
     { value: 'expired', label: 'Expired' },
     { value: 'not_requested', label: 'Not Requested' },
   ];
+
+  const openRejectionDialog = (documentId: string, documentName: string, note?: string | null) => {
+    setRejectionTarget({ id: documentId, name: documentName, note: note ?? '' });
+    setRejectionNoteValue(note ?? '');
+    setRejectionNoteError(null);
+  };
+
+  const handleRejectionSubmit = async (): Promise<void> => {
+    if (!rejectionTarget) {
+      return;
+    }
+
+    const normalizedNote = rejectionNoteValue.trim();
+    if (!normalizedNote) {
+      setRejectionNoteError('A rejection note is required.');
+      return;
+    }
+
+    setRejectionNoteError(null);
+    await onUpdateDocumentStatus(rejectionTarget.id, 'rejected', normalizedNote);
+    setRejectionTarget(null);
+    setRejectionNoteValue('');
+  };
 
   return (
     <>
@@ -123,15 +152,15 @@ export function DocumentsSection({
           </div>
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
             <div className="text-2xl font-bold text-blue-700">{documentStats.received}</div>
-            <div className="text-sm text-blue-600">Received</div>
+            <div className="text-sm text-blue-600">Received / Under Review</div>
           </div>
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
             <div className="text-2xl font-bold text-yellow-700">{documentStats.pending}</div>
-            <div className="text-sm text-yellow-600">Pending</div>
+            <div className="text-sm text-yellow-600">Requested</div>
           </div>
-          <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-            <div className="text-2xl font-bold text-orange-700">{documentStats.needsRevision}</div>
-            <div className="text-sm text-orange-600">Needs Revision</div>
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <div className="text-2xl font-bold text-red-700">{documentStats.rejected}</div>
+            <div className="text-sm text-red-600">Rejected</div>
           </div>
         </div>
 
@@ -201,7 +230,7 @@ export function DocumentsSection({
                 </div>
                 <div className="flex items-center gap-4">
                   <div className="text-sm text-gray-600">
-                    {suite.documents.filter((document) => ['approved', 'received'].includes(document.status)).length} /{' '}
+                    {suite.documents.filter((document) => ['approved', 'received_under_review'].includes(document.status)).length} /{' '}
                     {suite.documents.length} complete
                   </div>
                 </div>
@@ -240,19 +269,26 @@ export function DocumentsSection({
                               <span
                                 className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium border ${statusColor(document.status)}`}
                               >
-                                {titleize(document.status)}
+                                {documentStatusLabel(document.status)}
                               </span>
                               <select
                                 value={document.status}
                                 onClick={(event) => event.stopPropagation()}
-                                onChange={(event) =>
-                                  void onUpdateDocumentStatus(
-                                    document.id,
-                                    event.target.value as CaseDocumentStatus
-                                  )
-                                }
+                                onChange={(event) => {
+                                  const nextStatus = event.target.value as CaseDocumentStatus;
+                                  if (nextStatus === 'rejected') {
+                                    openRejectionDialog(
+                                      document.id,
+                                      document.name,
+                                      document.rejection_note
+                                    );
+                                    return;
+                                  }
+
+                                  void onUpdateDocumentStatus(document.id, nextStatus, null);
+                                }}
                                 disabled={updatingDocumentId === document.id}
-                                className="w-40 px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-800 disabled:opacity-60"
+                                className="w-48 px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-800 disabled:opacity-60"
                               >
                                 {documentStatusOptions.map((statusOption) => (
                                   <option key={statusOption.value} value={statusOption.value}>
@@ -260,6 +296,11 @@ export function DocumentsSection({
                                   </option>
                                 ))}
                               </select>
+                              {document.rejection_note ? (
+                                <p className="max-w-xs text-[11px] leading-5 text-red-700 whitespace-pre-wrap">
+                                  Rejection note: {document.rejection_note}
+                                </p>
+                              ) : null}
                             </div>
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-600">{formatDate(document.due_date)}</td>
@@ -371,6 +412,64 @@ export function DocumentsSection({
           onClose={() => setDeleteTarget(null)}
           onConfirm={handleDeleteDocument}
         />
+      ) : null}
+      {rejectionTarget ? (
+        <CaseConfigDialog
+          title="Reject Document"
+          description="Explain why this file was rejected and what the client should upload instead."
+          onClose={() => {
+            setRejectionTarget(null);
+            setRejectionNoteValue('');
+            setRejectionNoteError(null);
+          }}
+        >
+          <div className="px-6 py-5 space-y-4">
+            <p className="text-sm text-gray-700">
+              Send a rejection note for <span className="font-semibold text-gray-900">{rejectionTarget.name}</span>.
+            </p>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Note to client</label>
+              <textarea
+                value={rejectionNoteValue}
+                onChange={(event) => setRejectionNoteValue(event.target.value)}
+                rows={4}
+                maxLength={2000}
+                placeholder="Explain what is wrong with the file and what the client should upload next."
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 focus:border-red-500 focus:outline-none"
+              />
+              <div className="mt-1 flex items-center justify-between gap-3">
+                <span className="text-xs text-gray-500">{rejectionNoteValue.length}/2000</span>
+                {rejectionNoteError ? (
+                  <span className="text-xs text-red-600">{rejectionNoteError}</span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setRejectionTarget(null);
+                setRejectionNoteValue('');
+                setRejectionNoteError(null);
+              }}
+              disabled={updatingDocumentId === rejectionTarget.id}
+              className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void handleRejectionSubmit();
+              }}
+              disabled={updatingDocumentId === rejectionTarget.id}
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-60"
+            >
+              {updatingDocumentId === rejectionTarget.id ? 'Sending...' : 'Reject and Send Note'}
+            </button>
+          </div>
+        </CaseConfigDialog>
       ) : null}
       {noteTarget ? (
         <div className="fixed inset-0 z-[85] bg-black/60 backdrop-blur-sm flex items-center justify-center p-4">

--- a/frontend/figma/components/case-configuration/types.ts
+++ b/frontend/figma/components/case-configuration/types.ts
@@ -17,7 +17,7 @@ export type DocumentStats = {
   approved: number;
   received: number;
   pending: number;
-  needsRevision: number;
+  rejected: number;
 };
 
 export type MilestoneStats = {

--- a/frontend/figma/components/case-configuration/utils.ts
+++ b/frontend/figma/components/case-configuration/utils.ts
@@ -42,21 +42,47 @@ export function titleize(value: string): string {
     .join(' ');
 }
 
+export function documentStatusLabel(status: string): string {
+  switch (status) {
+    case 'requested':
+    case 'pending':
+      return 'Requested';
+    case 'received_under_review':
+    case 'received':
+    case 'under_review':
+    case 'under-review':
+      return 'Received / Under Review';
+    case 'approved':
+      return 'Approved';
+    case 'rejected':
+    case 'needs_revision':
+    case 'needs-revision':
+      return 'Rejected';
+    case 'not_requested':
+    case 'not-requested':
+      return 'Not Requested';
+    case 'expired':
+      return 'Expired';
+    default:
+      return titleize(status);
+  }
+}
+
 export function statusColor(status: string): string {
   switch (status) {
     case 'approved':
       return 'bg-green-100 text-green-700 border-green-200';
+    case 'received_under_review':
     case 'received':
-      return 'bg-blue-100 text-blue-700 border-blue-200';
     case 'under_review':
     case 'under-review':
       return 'bg-indigo-100 text-indigo-700 border-indigo-200';
+    case 'requested':
     case 'pending':
       return 'bg-yellow-100 text-yellow-700 border-yellow-200';
+    case 'rejected':
     case 'needs_revision':
     case 'needs-revision':
-      return 'bg-orange-100 text-orange-700 border-orange-200';
-    case 'rejected':
       return 'bg-red-100 text-red-700 border-red-200';
     case 'expired':
       return 'bg-slate-100 text-slate-700 border-slate-200';

--- a/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
+++ b/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
@@ -50,6 +50,14 @@ export const DocumentChecklist: Story = {
       downloadingDocumentId={null}
     />
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Requested')).toBeInTheDocument();
+    await expect(await canvas.findByText('Received / Under Review')).toBeInTheDocument();
+    await expect(await canvas.findByText('Rejected')).toBeInTheDocument();
+    await expect(await canvas.findByText('Rejection note')).toBeInTheDocument();
+  },
 };
 
 export const DocumentUploadModal: Story = {
@@ -94,7 +102,14 @@ export const Milestones: Story = {
 };
 
 export const Messages: Story = {
-  render: () => <MessagesPanel recentMessages={mockDashboardMessages} canSendMessages />,
+  render: () => <MessagesPanel recentMessages={mockDashboardMessages} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole('heading', { name: 'Lawyer Messages' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /send message/i })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /messaging disabled/i })).not.toBeInTheDocument();
+  },
 };
 
 export const Appointments: Story = {

--- a/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
+++ b/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
@@ -23,9 +23,11 @@ function documentStatusMeta(status: DashboardDocumentStatus) {
     case 'completed':
       return { color: 'text-green-600 bg-green-50', icon: CheckCircle, text: 'Uploaded' };
     case 'pending':
-      return { color: 'text-red-600 bg-red-50', icon: AlertCircle, text: 'Required' };
+      return { color: 'text-red-600 bg-red-50', icon: AlertCircle, text: 'Requested' };
     case 'review':
-      return { color: 'text-yellow-600 bg-yellow-50', icon: Clock, text: 'Under Review' };
+      return { color: 'text-yellow-600 bg-yellow-50', icon: Clock, text: 'Received / Under Review' };
+    case 'rejected':
+      return { color: 'text-red-700 bg-red-100', icon: AlertCircle, text: 'Rejected' };
     default:
       return { color: 'text-gray-600 bg-gray-50', icon: FileText, text: 'Optional' };
   }
@@ -132,6 +134,16 @@ export function DocumentChecklistPanel({
                       {document.instructions ? (
                         <p className="mt-2 text-xs text-gray-500">{document.instructions}</p>
                       ) : null}
+                      {document.rejectionNote ? (
+                        <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2">
+                          <p className="text-[11px] font-semibold uppercase tracking-wide text-red-700">
+                            Rejection note
+                          </p>
+                          <p className="mt-1 text-xs text-red-700 whitespace-pre-wrap">
+                            {document.rejectionNote}
+                          </p>
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
@@ -151,7 +163,7 @@ export function DocumentChecklistPanel({
                     <button
                       className={`px-4 py-2 rounded-lg flex items-center gap-2 transition-colors ${
                         canUploadDocuments
-                          ? document.status === 'pending'
+                          ? ['pending', 'rejected'].includes(document.status)
                             ? 'bg-red-600 hover:bg-red-700 text-white'
                             : 'border border-gray-300 hover:bg-gray-50 text-gray-700'
                           : 'bg-gray-200 text-gray-500 cursor-not-allowed'

--- a/frontend/figma/components/client-dashboard/MessagesPanel.tsx
+++ b/frontend/figma/components/client-dashboard/MessagesPanel.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { DashboardMessage } from './types';
@@ -6,10 +6,9 @@ import type { DashboardMessage } from './types';
 type MessagesPanelProps = {
   allMessages?: DashboardMessage[];
   recentMessages: DashboardMessage[];
-  canSendMessages: boolean;
 };
 
-export function MessagesPanel({ allMessages, recentMessages, canSendMessages }: MessagesPanelProps) {
+export function MessagesPanel({ allMessages, recentMessages }: MessagesPanelProps) {
   const [selectedMessage, setSelectedMessage] = useState<DashboardMessage | null>(null);
   const [isBoardOpen, setIsBoardOpen] = useState(false);
 
@@ -34,7 +33,7 @@ export function MessagesPanel({ allMessages, recentMessages, canSendMessages }: 
       <div className="bg-white rounded-lg shadow-sm">
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-gray-900">Messages</h2>
+            <h2 className="text-lg font-semibold text-gray-900">Lawyer Messages</h2>
             <button
               className="text-sm text-red-600 hover:text-red-700 font-medium disabled:text-gray-400 disabled:cursor-not-allowed"
               onClick={openBoard}
@@ -64,19 +63,6 @@ export function MessagesPanel({ allMessages, recentMessages, canSendMessages }: 
               <p className="text-xs text-gray-500 line-clamp-2">{message.preview}</p>
             </button>
           ))}
-        </div>
-        <div className="p-4 border-t border-gray-200">
-          <button
-            className={`w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 transition-colors ${
-              canSendMessages
-                ? 'bg-red-600 hover:bg-red-700 text-white'
-                : 'bg-gray-200 text-gray-500 cursor-not-allowed'
-            }`}
-            disabled={!canSendMessages}
-          >
-            <MessageSquare className="w-4 h-4" />
-            {canSendMessages ? 'Send Message' : 'Messaging Disabled'}
-          </button>
         </div>
       </div>
       {selectedMessage ? (

--- a/frontend/figma/components/client-dashboard/types.ts
+++ b/frontend/figma/components/client-dashboard/types.ts
@@ -1,4 +1,4 @@
-export type DashboardDocumentStatus = 'completed' | 'pending' | 'review' | 'optional';
+export type DashboardDocumentStatus = 'completed' | 'pending' | 'review' | 'rejected' | 'optional';
 
 export type DashboardDocument = {
   id: string;
@@ -10,6 +10,7 @@ export type DashboardDocument = {
   instructions: string | null;
   fileName: string | null;
   canDownload: boolean;
+  rejectionNote: string | null;
 };
 
 export type DashboardMilestone = {

--- a/frontend/figma/components/client-dashboard/useClientDashboardData.ts
+++ b/frontend/figma/components/client-dashboard/useClientDashboardData.ts
@@ -21,7 +21,7 @@ import {
   type DashboardMilestone,
   type ClientPortalCapabilities,
 } from './types';
-import { documentDisplayStatus, formatDate, relativeTime, titleize } from './utils';
+import { documentDisplayStatus, documentStatusLabel, formatDate, relativeTime, titleize } from './utils';
 
 type ClientDashboardData = {
   clientCases: ClientCaseListItem[];
@@ -264,12 +264,13 @@ export function useClientDashboardData(): ClientDashboardData {
       id: document.id,
       name: document.name,
       status: documentDisplayStatus(document.status, document.required),
-      lawyerStatus: titleize(document.status),
+      lawyerStatus: documentStatusLabel(document.status),
       uploadedDate: formatDate(document.uploaded_at),
       required: document.required,
       instructions: document.instructions,
       fileName: document.file_name,
       canDownload: document.can_download,
+      rejectionNote: document.rejection_note ?? null,
     }));
   }, [workspace, capabilities.canViewDocuments]);
 

--- a/frontend/figma/components/client-dashboard/utils.ts
+++ b/frontend/figma/components/client-dashboard/utils.ts
@@ -36,12 +36,37 @@ export function titleize(value: string): string {
     .join(' ');
 }
 
+export function documentStatusLabel(status: string): string {
+  switch (status) {
+    case 'requested':
+    case 'pending':
+      return 'Requested';
+    case 'received_under_review':
+    case 'received':
+    case 'under_review':
+      return 'Received / Under Review';
+    case 'approved':
+      return 'Approved';
+    case 'rejected':
+    case 'needs_revision':
+      return 'Rejected';
+    case 'not_requested':
+      return 'Not Requested';
+    default:
+      return titleize(status);
+  }
+}
+
 export function documentDisplayStatus(status: string, required: boolean): DashboardDocumentStatus {
-  if (['approved', 'received', 'completed'].includes(status)) {
+  if (status === 'rejected' || status === 'needs_revision') {
+    return 'rejected';
+  }
+
+  if (['approved', 'completed'].includes(status)) {
     return 'completed';
   }
 
-  if (['under_review', 'review', 'needs_revision'].includes(status)) {
+  if (['received_under_review', 'received', 'under_review', 'review'].includes(status)) {
     return 'review';
   }
 

--- a/frontend/figma/storybook/fixtures.ts
+++ b/frontend/figma/storybook/fixtures.ts
@@ -225,10 +225,11 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-reference',
           name: 'Employer Reference Letter',
           required: true,
-          status: 'needs_revision',
+          status: 'rejected',
           due_date: '2026-03-05',
           uploaded_at: '2026-02-19T16:30:00Z',
           instructions: 'Must include duties, salary, and duration.',
+          rejection_note: 'Please upload a signed employer letter that includes salary, duties, and exact dates.',
           file_name: 'reference-letter.pdf',
           latest_case_document_id: 'case-doc-reference',
           can_download: true,
@@ -237,7 +238,7 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-paystubs',
           name: 'Recent Pay Stubs',
           required: true,
-          status: 'received',
+          status: 'received_under_review',
           due_date: '2026-03-05',
           uploaded_at: '2026-02-20T10:15:00Z',
           instructions: 'Upload the last three months.',
@@ -257,7 +258,7 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-travel-history',
           name: 'Travel History Summary',
           required: false,
-          status: 'pending',
+          status: 'requested',
           due_date: '2026-03-10',
           uploaded_at: null,
           instructions: 'Provide a list of trips taken in the last 10 years.',
@@ -417,7 +418,7 @@ mockCaseWorkspaceSecondary.document_suites = mockCaseWorkspaceSecondary.document
     document.id === 'doc-reference'
       ? {
           ...document,
-          status: 'pending',
+          status: 'requested',
           uploaded_at: null,
           file_name: null,
           latest_case_document_id: null,
@@ -426,7 +427,7 @@ mockCaseWorkspaceSecondary.document_suites = mockCaseWorkspaceSecondary.document
       : document.id === 'doc-paystubs'
         ? {
             ...document,
-            status: 'received',
+            status: 'received_under_review',
             uploaded_at: '2026-02-18T10:15:00Z',
             file_name: 'work-permit-paystubs.zip',
             latest_case_document_id: 'case-doc-work-permit-paystubs',
@@ -502,24 +503,34 @@ export const mockDashboardDocuments: DashboardDocument[] = mockCaseWorkspace.doc
     id: document.id,
     name: document.name,
     status:
-      document.status === 'approved'
+      document.status === 'rejected'
+        ? 'rejected'
+        : document.status === 'approved'
         ? 'completed'
-        : document.status === 'received' || document.status === 'under_review'
+        : document.status === 'received_under_review' || document.status === 'received' || document.status === 'under_review'
           ? 'review'
           : document.required
             ? 'pending'
             : 'optional',
-    lawyerStatus: document.status
-      .replaceAll('_', ' ')
-      .split(' ')
-      .filter(Boolean)
-      .map((part) => part[0].toUpperCase() + part.slice(1))
-      .join(' '),
+    lawyerStatus:
+      document.status === 'received_under_review'
+        ? 'Received / Under Review'
+        : document.status === 'requested'
+          ? 'Requested'
+          : document.status === 'rejected'
+            ? 'Rejected'
+            : document.status
+                .replaceAll('_', ' ')
+                .split(' ')
+                .filter(Boolean)
+                .map((part) => part[0].toUpperCase() + part.slice(1))
+                .join(' '),
     uploadedDate: document.uploaded_at ?? 'Pending',
     required: document.required,
     instructions: document.instructions,
     fileName: document.file_name,
     canDownload: document.can_download,
+    rejectionNote: document.rejection_note ?? null,
   }));
 
 export const mockDashboardMilestones: DashboardMilestone[] = [

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -288,6 +288,7 @@ export type CaseWorkspace = {
       uploaded_at: string | null;
       instructions: string | null;
       client_note?: string | null;
+      rejection_note?: string | null;
       file_name: string | null;
       latest_case_document_id: string | null;
       can_download: boolean;
@@ -302,6 +303,7 @@ export type CaseWorkspace = {
     uploaded_at: string | null;
     instructions: string | null;
     client_note?: string | null;
+    rejection_note?: string | null;
     file_name: string | null;
     latest_case_document_id: string | null;
     can_download: boolean;
@@ -374,12 +376,10 @@ export type CaseCustomDocumentSuiteCreateInput = {
 };
 
 export type CaseDocumentStatus =
-  | 'pending'
-  | 'received'
-  | 'under_review'
+  | 'requested'
+  | 'received_under_review'
   | 'approved'
   | 'rejected'
-  | 'needs_revision'
   | 'expired'
   | 'not_requested';
 
@@ -1003,13 +1003,14 @@ export async function createCaseCustomDocumentSuite(
 export async function updateCaseDocumentStatus(
   caseNumber: string,
   documentId: string,
-  status: CaseDocumentStatus
-): Promise<{ document_id: string; status: CaseDocumentStatus }> {
-  return requestJson<{ document_id: string; status: CaseDocumentStatus }>(
+  status: CaseDocumentStatus,
+  rejectionNote?: string | null
+): Promise<{ document_id: string; status: CaseDocumentStatus; rejection_note?: string | null }> {
+  return requestJson<{ document_id: string; status: CaseDocumentStatus; rejection_note?: string | null }>(
     `/api/v1/cases/by-number/${encodeURIComponent(caseNumber)}/documents/${encodeURIComponent(documentId)}/status`,
     {
       method: 'PATCH',
-      body: JSON.stringify({ status }),
+      body: JSON.stringify({ status, rejection_note: rejectionNote ?? null }),
     }
   );
 }


### PR DESCRIPTION
# Pull Request

Summary:
Simplified lawyer/client document statuses to Requested, Received / Under Review, Approved, and Rejected.
Added a lawyer rejection-note flow so rejected documents require an explanation for the client.
Showed rejection notes on the client dashboard and cleared them automatically when a client uploads a replacement file.
Renamed the client Messages panel to Lawyer Messages and removed the send button for the one-way messaging setup.
Added frontend Storybook coverage for the updated client document and message UI.
Added backend regression coverage for rejection-note and resubmission behavior.

User impact:
Lawyers and clients now see the same clearer document status language.
Rejected files include actionable guidance for clients.
When a client uploads a corrected file, it returns to review and the old rejection note disappears.
Client messaging now matches the intended read-only experience.

Technical details:
Backend status normalization now maps legacy document states into the new shared status model.
Document status updates support persisted rejection notes.
Client and lawyer dashboard UI were updated to use the new labels and rejection-note handling.
Re-upload logic now clears rejection overrides and rejection notes automatically.

