### PR TITLE
Fix non required document updating message reminders, a lot of minor things

### DIFF
--- a/backend/app/api/routes/cases.py
+++ b/backend/app/api/routes/cases.py
@@ -82,6 +82,7 @@ ALLOWED_DOCUMENT_STATUSES = {
     "received",
     "not_requested",
     "accepted",
+    "rejected",
 }
 ALLOWED_CASE_PRIORITIES = {"low", "medium", "high", "urgent"}
 ALLOWED_CASE_STATUSES = {
@@ -114,8 +115,8 @@ LEGACY_DOCUMENT_STATUS_MAP = {
     "pending": "requested",
     "under_review": "received",
     "approved": "accepted",
-    "rejected": "requested",
-    "needs_revision": "requested",
+    "rejected": "rejected",
+    "needs_revision": "rejected",
     "expired": "requested",
     "optional": "not_requested",
     "completed": "accepted",
@@ -306,6 +307,20 @@ def _normalized_document_status_overrides(raw: Any) -> dict[str, str]:
         if not doc_id or status_value not in ALLOWED_DOCUMENT_STATUSES:
             continue
         normalized[doc_id] = status_value
+    return normalized
+
+
+def _normalized_document_rejection_notes(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        doc_id = str(key).strip()
+        note = str(value or "").strip()
+        if not doc_id or not note:
+            continue
+        normalized[doc_id] = note[:2000]
     return normalized
 
 
@@ -1586,6 +1601,9 @@ def get_case_workspace_by_number(
         custom_fields.get("hidden_document_ids")
     )
     custom_documents = _normalized_custom_documents(custom_fields.get("custom_documents"))
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
     portal_permissions_payload = _normalized_portal_permissions(custom_fields.get("portal_permissions"))
     is_client_portal_view = (
         "client" in auth.roles
@@ -1695,6 +1713,7 @@ def get_case_workspace_by_number(
                     uploaded_at=document_row["uploaded_at"],
                     instructions=document_row["instructions"],
                     client_note=document_row.get("client_note"),
+                    rejection_note=rejection_notes.get(template_id_str),
                     file_name=document_row["file_name"],
                     latest_case_document_id=(
                         str(document_row["latest_case_document_id"])
@@ -1778,6 +1797,7 @@ def get_case_workspace_by_number(
                 uploaded_at=custom_document_row["uploaded_at"],
                 instructions="",
                 client_note=custom_document_row.get("client_note"),
+                rejection_note=rejection_notes.get(custom_document_id),
                 file_name=custom_document_row["file_name"],
                 latest_case_document_id=custom_document_id,
                 can_download=True,
@@ -1836,6 +1856,7 @@ def get_case_workspace_by_number(
                 uploaded_at=bound_uploaded_at,
                 instructions=custom_document["instructions"],
                 client_note=bound_client_note,
+                rejection_note=rejection_notes.get(custom_document_id),
                 file_name=bound_file_name,
                 latest_case_document_id=str(bound_case_document["id"]) if bound_case_document else None,
                 can_download=bound_case_document is not None,
@@ -2484,6 +2505,8 @@ def delete_case_document(
     name_overrides.pop(str(document_uuid), None)
     status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
     status_overrides.pop(str(document_uuid), None)
+    rejection_notes = _normalized_document_rejection_notes(custom_fields.get("document_rejection_notes"))
+    rejection_notes.pop(str(document_uuid), None)
 
     case.custom_fields = {
         **custom_fields,
@@ -2491,6 +2514,7 @@ def delete_case_document(
         "hidden_document_ids": sorted(hidden_document_ids),
         "document_name_overrides": name_overrides,
         "document_status_overrides": status_overrides,
+        "document_rejection_notes": rejection_notes,
     }
 
     log_activity(
@@ -2525,6 +2549,12 @@ def update_case_document_status(
     normalized_status = _canonical_document_status(payload.status)
     if normalized_status not in ALLOWED_DOCUMENT_STATUSES:
         raise HTTPException(status_code=400, detail="Invalid document status")
+
+    normalized_rejection_note = (payload.rejection_note or "").strip() or None
+    if normalized_rejection_note and len(normalized_rejection_note) > 2000:
+        raise HTTPException(status_code=400, detail="Rejection note must be 2000 characters or fewer")
+    if normalized_status == "rejected" and not normalized_rejection_note:
+        raise HTTPException(status_code=400, detail="Rejection note is required when rejecting a document")
 
     try:
         document_uuid = UUID(document_id)
@@ -2582,6 +2612,9 @@ def update_case_document_status(
     status_overrides = _normalized_document_status_overrides(
         custom_fields.get("document_status_overrides")
     )
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
 
     if custom_document_exists:
         for custom_document in custom_documents:
@@ -2589,14 +2622,27 @@ def update_case_document_status(
                 custom_document["status"] = normalized_status
                 break
         status_overrides.pop(str(document_uuid), None)
+        if normalized_status == "rejected" and normalized_rejection_note:
+            rejection_notes[str(document_uuid)] = normalized_rejection_note
+        else:
+            rejection_notes.pop(str(document_uuid), None)
         case.custom_fields = {
             **custom_fields,
             "custom_documents": custom_documents,
             "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
         }
     else:
         status_overrides[str(document_uuid)] = normalized_status
-        case.custom_fields = {**custom_fields, "document_status_overrides": status_overrides}
+        if normalized_status == "rejected" and normalized_rejection_note:
+            rejection_notes[str(document_uuid)] = normalized_rejection_note
+        else:
+            rejection_notes.pop(str(document_uuid), None)
+        case.custom_fields = {
+            **custom_fields,
+            "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
+        }
 
     db.add(case)
     db.commit()
@@ -2604,6 +2650,7 @@ def update_case_document_status(
     return CaseDocumentStatusUpdateResponse(
         document_id=str(document_uuid),
         status=normalized_status,
+        rejection_note=normalized_rejection_note if normalized_status == "rejected" else None,
     )
 
 
@@ -2766,18 +2813,32 @@ def complete_case_document_upload(
     if insert_result is None:
         raise HTTPException(status_code=500, detail="Failed to record uploaded document")
 
+    custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
+    status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
+    rejection_notes = _normalized_document_rejection_notes(
+        custom_fields.get("document_rejection_notes")
+    )
+    rejection_notes.pop(slot["logical_document_id"], None)
+
     if slot["kind"] == "custom_request":
-        custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
         upload_bindings = _normalized_document_upload_bindings(custom_fields.get("document_upload_bindings"))
         upload_bindings[slot["logical_document_id"]] = str(insert_result["id"])
-        status_overrides = _normalized_document_status_overrides(custom_fields.get("document_status_overrides"))
-        status_overrides.pop(slot["logical_document_id"], None)
+        status_overrides[slot["logical_document_id"]] = "received"
         case.custom_fields = {
             **custom_fields,
             "document_upload_bindings": upload_bindings,
             "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
         }
-        db.add(case)
+    else:
+        status_overrides.pop(slot["logical_document_id"], None)
+        case.custom_fields = {
+            **custom_fields,
+            "document_status_overrides": status_overrides,
+            "document_rejection_notes": rejection_notes,
+        }
+
+    db.add(case)
 
     log_activity(
         db,
@@ -2816,6 +2877,7 @@ def complete_case_document_upload(
         uploaded_at=insert_result["uploaded_at"],
         instructions=slot["instructions"],
         client_note=normalized_client_note,
+        rejection_note=None,
         file_name=actual_file_name,
         latest_case_document_id=str(insert_result["id"]),
         can_download=True,
@@ -2868,9 +2930,17 @@ def delete_client_uploaded_document(
     if slot["kind"] == "custom_request":
         custom_fields = case.custom_fields if isinstance(case.custom_fields, dict) else {}
         upload_bindings = _normalized_document_upload_bindings(custom_fields.get("document_upload_bindings"))
+        status_overrides = _normalized_document_status_overrides(
+            custom_fields.get("document_status_overrides")
+        )
         if upload_bindings.get(slot["logical_document_id"]) == str(case_document["id"]):
             upload_bindings.pop(slot["logical_document_id"], None)
-            case.custom_fields = {**custom_fields, "document_upload_bindings": upload_bindings}
+            status_overrides.pop(slot["logical_document_id"], None)
+            case.custom_fields = {
+                **custom_fields,
+                "document_upload_bindings": upload_bindings,
+                "document_status_overrides": status_overrides,
+            }
             db.add(case)
 
     log_activity(

--- a/backend/app/schemas/case.py
+++ b/backend/app/schemas/case.py
@@ -83,6 +83,7 @@ class CaseWorkspaceDocument(BaseModel):
     uploaded_at: Optional[datetime]
     instructions: Optional[str]
     client_note: Optional[str] = None
+    rejection_note: Optional[str] = None
     file_name: Optional[str] = None
     latest_case_document_id: Optional[str] = None
     can_download: bool = False
@@ -177,11 +178,13 @@ class CaseCustomDocumentSuiteCreateRequest(BaseModel):
 
 class CaseDocumentStatusUpdateRequest(BaseModel):
     status: str
+    rejection_note: Optional[str] = None
 
 
 class CaseDocumentStatusUpdateResponse(BaseModel):
     document_id: str
     status: str
+    rejection_note: Optional[str] = None
 
 
 class CaseDocumentUploadInitiateRequest(BaseModel):

--- a/backend/tests/api/routes/test_cases.py
+++ b/backend/tests/api/routes/test_cases.py
@@ -611,17 +611,136 @@ def test_update_case_document_status_updates_custom_document(monkeypatch, make_a
     db = MagicMock()
     db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
     monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(
+        cases,
+        '_resolve_document_slot',
+        lambda **kwargs: {
+            'kind': 'custom_request',
+            'logical_document_id': document_id,
+            'bound_case_document': None,
+        },
+    )
 
     result = cases.update_case_document_status(
         case_number='C-2026-001',
         document_id=document_id,
-        payload=CaseDocumentStatusUpdateRequest(status='approved'),
+        payload=CaseDocumentStatusUpdateRequest(status='accepted'),
         auth=auth,
         db=db,
     )
 
     assert result.status == 'accepted'
     assert case.custom_fields['custom_documents'][0]['status'] == 'accepted'
+
+
+def test_update_case_document_status_rejected_requires_note(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'received'}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(
+        cases,
+        '_resolve_document_slot',
+        lambda **kwargs: {
+            'kind': 'custom_request',
+            'logical_document_id': document_id,
+            'bound_case_document': None,
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        cases.update_case_document_status(
+            case_number='C-2026-001',
+            document_id=document_id,
+            payload=CaseDocumentStatusUpdateRequest(status='rejected'),
+            auth=auth,
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == 'Rejection note is required when rejecting a document'
+
+
+def test_update_case_document_status_rejected_stores_note(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': True, 'status': 'received'}]},
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+    monkeypatch.setattr(
+        cases,
+        '_resolve_document_slot',
+        lambda **kwargs: {
+            'kind': 'custom_request',
+            'logical_document_id': document_id,
+            'bound_case_document': None,
+        },
+    )
+
+    result = cases.update_case_document_status(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentStatusUpdateRequest(
+            status='rejected',
+            rejection_note='This scan is blurry. Please upload a clearer copy.'
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'rejected'
+    assert result.rejection_note == 'This scan is blurry. Please upload a clearer copy.'
+    assert case.custom_fields['custom_documents'][0]['status'] == 'rejected'
+    assert case.custom_fields['document_rejection_notes'][document_id] == (
+        'This scan is blurry. Please upload a clearer copy.'
+    )
+
+
+def test_update_case_document_status_rejected_keeps_bound_upload_record(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['lawyer'])
+    document_id = str(uuid4())
+    bound_case_document_id = uuid4()
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        case_type='Express Entry',
+        custom_fields={
+            'custom_documents': [{'id': document_id, 'name': 'Passport', 'required': False, 'status': 'requested'}],
+            'document_upload_bindings': {document_id: str(bound_case_document_id)},
+        },
+    )
+    db = MagicMock()
+    db.execute.side_effect = [FakeResult(rows=[]), FakeResult(rows=[])]
+    monkeypatch.setattr(cases, '_get_case_with_write_access', lambda **kwargs: case)
+
+    result = cases.update_case_document_status(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentStatusUpdateRequest(
+            status='rejected',
+            rejection_note='Wrong document. Please upload the requested file.'
+        ),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'rejected'
+    assert case.custom_fields['document_upload_bindings'][document_id] == str(bound_case_document_id)
+    assert case.custom_fields['custom_documents'][0]['status'] == 'rejected'
+
 
 
 def test_initiate_case_document_upload_returns_presigned_upload(monkeypatch, make_auth_context):
@@ -689,6 +808,58 @@ def test_complete_case_document_upload_records_upload(monkeypatch, make_auth_con
 
     assert result.status == 'received'
     assert result.can_download is True
+
+
+def test_complete_case_document_upload_marks_requested_custom_document_received(monkeypatch, make_auth_context):
+    auth = make_auth_context(roles=['client'])
+    document_id = str(uuid4())
+    case = row(
+        id=uuid4(),
+        organization_id=auth.organization_id,
+        client_id=auth.user_id,
+        custom_fields={
+            'custom_documents': [{'id': document_id, 'name': 'Travel History', 'required': False, 'status': 'requested'}],
+            'document_rejection_notes': {document_id: 'Old rejection note'},
+        },
+    )
+    slot = {
+        'kind': 'custom_request',
+        'logical_document_id': document_id,
+        'template_id': None,
+        'name': 'Travel History',
+        'required': False,
+        'instructions': 'Upload travel history',
+        'previous_case_document_id': None,
+        'next_version': 1,
+    }
+    storage_key = f'org/{case.organization_id}/case/{case.id}/documents/{document_id}/uuid-travel-history.pdf'
+    inserted_id = uuid4()
+    db = MagicMock()
+    db.execute.return_value = FakeResult(rows=[{'id': inserted_id, 'uploaded_at': datetime.now(timezone.utc)}])
+    monkeypatch.setattr(cases, '_get_case_with_access', lambda **kwargs: case)
+    monkeypatch.setattr(cases, '_resolve_document_slot', lambda **kwargs: slot)
+    monkeypatch.setattr(cases, 'head_object', lambda **kwargs: {'ContentLength': 1024, 'ContentType': 'application/pdf'})
+    monkeypatch.setattr(cases, 'log_activity', lambda *args, **kwargs: None)
+    monkeypatch.setattr(cases, 'log_document_access', lambda *args, **kwargs: None)
+
+    result = cases.complete_case_document_upload(
+        case_number='C-2026-001',
+        document_id=document_id,
+        payload=CaseDocumentUploadCompleteRequest(
+            storage_key=storage_key,
+            file_name='travel-history.pdf',
+            file_type='application/pdf',
+            file_size_bytes=1024,
+        ),
+        request=row(client=row(host='127.0.0.1'), headers={'user-agent': 'pytest'}),
+        auth=auth,
+        db=db,
+    )
+
+    assert result.status == 'received'
+    assert case.custom_fields['document_upload_bindings'][document_id] == str(inserted_id)
+    assert case.custom_fields['document_status_overrides'][document_id] == 'received'
+    assert case.custom_fields['document_rejection_notes'] == {}
 
 
 def test_get_case_document_view_url_returns_inline_presigned_link(monkeypatch, make_auth_context):

--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -117,7 +117,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
   const [isCreatingDocumentSuite, setIsCreatingDocumentSuite] = useState(false);
   const [isAddingDocument, setIsAddingDocument] = useState(false);
   const [isSendingBulkReminders, setIsSendingBulkReminders] = useState(false);
-  const [sendingDocumentReminderId, setSendingDocumentReminderId] = useState<string | null>(null);
   const [renamingDocumentId, setRenamingDocumentId] = useState<string | null>(null);
   const [deletingDocumentId, setDeletingDocumentId] = useState<string | null>(null);
   const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
@@ -627,30 +626,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     }
   };
 
-  const handleSendDocumentReminder = async (documentId: string): Promise<void> => {
-    if (!workspace) {
-      return;
-    }
-
-    const documentName = workspace?.documents.find((document) => document.id === documentId)?.name ?? 'document';
-    setSendingDocumentReminderId(documentId);
-    try {
-      await createCaseReminder(workspace.case.case_number, {
-        title: 'Document Reminder',
-        body: `Please upload or update this document in your client portal: ${documentName}.`,
-        send_email_notification: true,
-        visible_to_client: true,
-      });
-      await refreshWorkspace(workspace.case.case_number);
-      showNotice('success', `Reminder sent for ${documentName}.`);
-    } catch (sendError) {
-      const message = sendError instanceof Error ? sendError.message : 'Unknown error';
-      showNotice('error', `Failed to send reminder: ${message}`);
-    } finally {
-      setSendingDocumentReminderId(null);
-    }
-  };
-
   const handleDeleteDocument = async (documentId: string): Promise<boolean> => {
     if (!workspace) {
       return false;
@@ -885,8 +860,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
           downloadingDocumentId={downloadingDocumentId}
           onUpdateDocumentStatus={handleUpdateDocumentStatus}
           updatingDocumentId={updatingDocumentId}
-          onSendDocumentReminder={handleSendDocumentReminder}
-          sendingDocumentReminderId={sendingDocumentReminderId}
           onDeleteDocument={handleDeleteDocument}
           deletingDocumentId={deletingDocumentId}
         />

--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -244,6 +244,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       received: 0,
       requested: 0,
       notRequested: 0,
+      rejected: 0,
     };
 
     if (!workspace) {
@@ -253,6 +254,8 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     for (const document of workspace.documents) {
       if (document.status === 'accepted') {
         stats.accepted += 1;
+      } else if (document.status === 'rejected') {
+        stats.rejected += 1;
       } else if (document.status === 'received') {
         stats.received += 1;
       } else if (document.status === 'not_requested') {
@@ -573,7 +576,11 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     }
   };
 
-  const handleUpdateDocumentStatus = async (documentId: string, status: CaseDocumentStatus) => {
+  const handleUpdateDocumentStatus = async (
+    documentId: string,
+    status: CaseDocumentStatus,
+    rejectionNote?: string | null
+  ) => {
     if (!workspace) {
       return;
     }
@@ -583,7 +590,8 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       const updated = await updateCaseDocumentStatus(
         workspace.case.case_number,
         documentId,
-        status
+        status,
+        rejectionNote
       );
 
       updateWorkspace((current) => ({
@@ -595,6 +603,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
               ? {
                   ...document,
                   status: updated.status,
+                  rejection_note: updated.rejection_note ?? null,
                 }
               : document
           ),
@@ -604,6 +613,7 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
             ? {
                 ...document,
                 status: updated.status,
+                rejection_note: updated.rejection_note ?? null,
               }
             : document
         ),

--- a/frontend/figma/components/ClientDashboard.tsx
+++ b/frontend/figma/components/ClientDashboard.tsx
@@ -29,11 +29,9 @@ export function ClientDashboard() {
     deleteUploadedDocument,
     downloadDocument,
     markReminderRead,
-    acknowledgeReminder,
     uploadingDocumentId,
     deletingDocumentId,
     downloadingDocumentId,
-    updatingReminderId,
   } = useClientDashboardData();
 
   if (loading) {
@@ -135,10 +133,7 @@ export function ClientDashboard() {
               <RemindersPanel
                 allReminders={allReminders}
                 recentReminders={recentReminders}
-                canAcknowledgeReminders={capabilities.canAcknowledgeReminders}
                 onMarkRead={markReminderRead}
-                onAcknowledge={acknowledgeReminder}
-                updatingReminderId={updatingReminderId}
               />
             ) : null}
             {capabilities.canViewMilestones ? (

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -95,8 +95,6 @@ export const Documents: Story = {
       viewingDocumentId={null}
       onUpdateDocumentStatus={updateDocumentStatus}
       updatingDocumentId={null}
-      onSendDocumentReminder={async () => {}}
-      sendingDocumentReminderId={null}
       onDeleteDocument={async () => true}
       deletingDocumentId={null}
     />

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -28,6 +28,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 const createReminder = fn(async () => true);
 const notifyReminder = fn();
+const updateDocumentStatus = fn(async () => {});
 
 export const Sidebar: Story = {
   parameters: { layout: 'fullscreen' },
@@ -75,7 +76,7 @@ export const Documents: Story = {
   render: () => (
     <DocumentsSection
       workspace={mockCaseWorkspace}
-      documentStats={{ accepted: 1, received: 1, requested: 1, notRequested: 1 }}
+      documentStats={{ accepted: 1, received: 1, requested: 1, notRequested: 1, rejected: 1 }}
       expandedSuites={mockCaseWorkspace.document_suites.map((suite) => suite.id)}
       onToggleSuite={() => {}}
       onAddCustomDocument={async () => true}
@@ -92,7 +93,7 @@ export const Documents: Story = {
       downloadingDocumentId={null}
       onViewDocument={async () => {}}
       viewingDocumentId={null}
-      onUpdateDocumentStatus={async () => {}}
+      onUpdateDocumentStatus={updateDocumentStatus}
       updatingDocumentId={null}
       onSendDocumentReminder={async () => {}}
       sendingDocumentReminderId={null}
@@ -100,6 +101,35 @@ export const Documents: Story = {
       deletingDocumentId={null}
     />
   ),
+  play: async ({ canvasElement }) => {
+    updateDocumentStatus.mockClear();
+    const canvas = within(canvasElement);
+    const referenceRow = canvas.getByText('Employer Reference Letter').closest('tr');
+
+    if (!referenceRow) {
+      throw new Error('Expected employer reference document row');
+    }
+
+    const statusSelect = referenceRow.querySelector('select');
+    if (!statusSelect) {
+      throw new Error('Expected status select to be rendered');
+    }
+
+    await userEvent.selectOptions(statusSelect, 'rejected');
+    await expect(canvas.getByRole('heading', { name: 'Reject Document' })).toBeInTheDocument();
+    await userEvent.clear(canvas.getByLabelText('Rejection note'));
+    await userEvent.type(
+      canvas.getByLabelText('Rejection note'),
+      'Please upload the complete signed letter with salary details.'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Reject Document' }));
+
+    await expect(updateDocumentStatus).toHaveBeenCalledWith(
+      'doc-reference',
+      'rejected',
+      'Please upload the complete signed letter with salary details.'
+    );
+  },
 };
 
 export const Milestones: Story = {

--- a/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
@@ -37,8 +37,6 @@ type DocumentsSectionProps = {
     rejectionNote?: string | null
   ) => Promise<void>;
   updatingDocumentId: string | null;
-  onSendDocumentReminder: (documentId: string) => Promise<void>;
-  sendingDocumentReminderId: string | null;
   onDeleteDocument: (documentId: string) => Promise<boolean>;
   deletingDocumentId: string | null;
 };
@@ -64,8 +62,6 @@ export function DocumentsSection({
   downloadingDocumentId,
   onUpdateDocumentStatus,
   updatingDocumentId,
-  onSendDocumentReminder,
-  sendingDocumentReminderId,
   onDeleteDocument,
   deletingDocumentId,
 }: DocumentsSectionProps) {
@@ -375,18 +371,9 @@ export function DocumentsSection({
                                   event.stopPropagation();
                                   setRenameTarget({ id: document.id, name: document.name });
                                 }}
+                                title="Rename Document"
                               >
                                 <Edit2 className="w-4 h-4 text-gray-600" />
-                              </button>
-                              <button
-                                className="p-1 hover:bg-gray-100 rounded disabled:opacity-50"
-                                disabled={sendingDocumentReminderId === document.id}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  void onSendDocumentReminder(document.id);
-                                }}
-                              >
-                                <Send className="w-4 h-4 text-gray-600" />
                               </button>
                               <button
                                 className="p-1 hover:bg-gray-100 rounded"
@@ -394,6 +381,7 @@ export function DocumentsSection({
                                   event.stopPropagation();
                                   setDeleteTarget({ id: document.id, name: document.name });
                                 }}
+                                title="Delete Document"
                               >
                                 <Trash2 className="w-4 h-4 text-gray-600" />
                               </button>

--- a/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/DocumentsSection.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronRight, Download, Edit2, Eye, FolderPlus, Plus, Send
 import type { CaseDocumentStatus, CaseWorkspace } from '@/lib/api';
 
 import { AddDocumentDialog } from '../dialogs/AddDocumentDialog';
+import { CaseConfigDialog } from '../dialogs/CaseConfigDialog';
 import { CreateSuiteDialog } from '../dialogs/CreateSuiteDialog';
 import { DeleteDocumentDialog } from '../dialogs/DeleteDocumentDialog';
 import { RenameDocumentDialog } from '../dialogs/RenameDocumentDialog';
@@ -30,7 +31,11 @@ type DocumentsSectionProps = {
   viewingDocumentId: string | null;
   onDownloadDocument: (documentId: string) => Promise<void>;
   downloadingDocumentId: string | null;
-  onUpdateDocumentStatus: (documentId: string, status: CaseDocumentStatus) => Promise<void>;
+  onUpdateDocumentStatus: (
+    documentId: string,
+    status: CaseDocumentStatus,
+    rejectionNote?: string | null
+  ) => Promise<void>;
   updatingDocumentId: string | null;
   onSendDocumentReminder: (documentId: string) => Promise<void>;
   sendingDocumentReminderId: string | null;
@@ -70,6 +75,12 @@ export function DocumentsSection({
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [noteTarget, setNoteTarget] = useState<{ name: string; note: string } | null>(null);
+  const [rejectionTarget, setRejectionTarget] = useState<{
+    id: string;
+    name: string;
+    note: string;
+  } | null>(null);
+  const [rejectionError, setRejectionError] = useState<string | null>(null);
 
   const handleCreateSuite = async (input: NewDocumentSuiteInput): Promise<boolean> => {
     setIsCreatingSuite(true);
@@ -101,10 +112,46 @@ export function DocumentsSection({
     }
   };
 
+  const handleStatusChange = (
+    documentId: string,
+    documentName: string,
+    currentRejectionNote: string | null | undefined,
+    nextStatus: CaseDocumentStatus
+  ) => {
+    if (nextStatus === 'rejected') {
+      setRejectionError(null);
+      setRejectionTarget({
+        id: documentId,
+        name: documentName,
+        note: currentRejectionNote ?? '',
+      });
+      return;
+    }
+
+    void onUpdateDocumentStatus(documentId, nextStatus, null);
+  };
+
+  const handleRejectDocument = async (): Promise<void> => {
+    if (!rejectionTarget) {
+      return;
+    }
+
+    const normalizedNote = rejectionTarget.note.trim();
+    if (!normalizedNote) {
+      setRejectionError('Add a short note explaining why the document was rejected.');
+      return;
+    }
+
+    setRejectionError(null);
+    await onUpdateDocumentStatus(rejectionTarget.id, 'rejected', normalizedNote);
+    setRejectionTarget(null);
+  };
+
   const documentStatusOptions: Array<{ value: CaseDocumentStatus; label: string }> = [
     { value: 'requested', label: 'Requested' },
     { value: 'received', label: 'Received' },
     { value: 'accepted', label: 'Accepted' },
+    { value: 'rejected', label: 'Rejected' },
     { value: 'not_requested', label: 'Not Requested' },
   ];
 
@@ -116,7 +163,7 @@ export function DocumentsSection({
           <p className="text-gray-600">Configure and manage document requests for this case</p>
         </div>
 
-        <div className="grid grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 xl:grid-cols-5 gap-4">
           <div className="bg-green-50 border border-green-200 rounded-lg p-4">
             <div className="text-2xl font-bold text-green-700">{documentStats.accepted}</div>
             <div className="text-sm text-green-600">Accepted</div>
@@ -128,6 +175,10 @@ export function DocumentsSection({
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
             <div className="text-2xl font-bold text-yellow-700">{documentStats.requested}</div>
             <div className="text-sm text-yellow-600">Requested</div>
+          </div>
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <div className="text-2xl font-bold text-red-700">{documentStats.rejected}</div>
+            <div className="text-sm text-red-600">Rejected</div>
           </div>
           <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
             <div className="text-2xl font-bold text-gray-700">{documentStats.notRequested}</div>
@@ -246,8 +297,10 @@ export function DocumentsSection({
                                 value={document.status}
                                 onClick={(event) => event.stopPropagation()}
                                 onChange={(event) =>
-                                  void onUpdateDocumentStatus(
+                                  handleStatusChange(
                                     document.id,
+                                    document.name,
+                                    document.rejection_note,
                                     event.target.value as CaseDocumentStatus
                                   )
                                 }
@@ -260,6 +313,11 @@ export function DocumentsSection({
                                   </option>
                                 ))}
                               </select>
+                              {document.rejection_note?.trim() ? (
+                                <p className="max-w-xs text-xs text-red-600">
+                                  Rejection note: {document.rejection_note}
+                                </p>
+                              ) : null}
                             </div>
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-600">{formatDate(document.due_date)}</td>
@@ -414,6 +472,70 @@ export function DocumentsSection({
             </div>
           </div>
         </div>
+      ) : null}
+      {rejectionTarget ? (
+        <CaseConfigDialog
+          title="Reject Document"
+          description="Explain why this document was rejected so the client knows what to replace."
+          onClose={() => {
+            setRejectionTarget(null);
+            setRejectionError(null);
+          }}
+        >
+          <div className="px-6 py-5 space-y-4">
+            <p className="text-sm text-gray-700">
+              Reject <span className="font-semibold text-gray-900">{rejectionTarget.name}</span>?
+            </p>
+            <div>
+              <label htmlFor="rejection-note" className="block text-sm font-medium text-gray-700 mb-2">
+                Rejection note
+              </label>
+              <textarea
+                id="rejection-note"
+                value={rejectionTarget.note}
+                onChange={(event) => {
+                  setRejectionError(null);
+                  setRejectionTarget((current) =>
+                    current
+                      ? {
+                          ...current,
+                          note: event.target.value,
+                        }
+                      : current
+                  );
+                }}
+                rows={4}
+                maxLength={2000}
+                placeholder="Tell the client what is wrong with this file and what they should upload instead."
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-100"
+              />
+              {rejectionError ? <p className="mt-2 text-xs text-red-600">{rejectionError}</p> : null}
+            </div>
+          </div>
+          <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setRejectionTarget(null);
+                setRejectionError(null);
+              }}
+              disabled={updatingDocumentId === rejectionTarget.id}
+              className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void handleRejectDocument();
+              }}
+              disabled={updatingDocumentId === rejectionTarget.id}
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-60"
+            >
+              {updatingDocumentId === rejectionTarget.id ? 'Saving...' : 'Reject Document'}
+            </button>
+          </div>
+        </CaseConfigDialog>
       ) : null}
     </>
   );

--- a/frontend/figma/components/case-configuration/types.ts
+++ b/frontend/figma/components/case-configuration/types.ts
@@ -17,6 +17,7 @@ export type DocumentStats = {
   received: number;
   requested: number;
   notRequested: number;
+  rejected: number;
 };
 
 export type MilestoneStats = {

--- a/frontend/figma/components/case-configuration/utils.ts
+++ b/frontend/figma/components/case-configuration/utils.ts
@@ -50,6 +50,8 @@ export function statusColor(status: string): string {
       return 'bg-blue-100 text-blue-700 border-blue-200';
     case 'requested':
       return 'bg-yellow-100 text-yellow-700 border-yellow-200';
+    case 'rejected':
+      return 'bg-red-100 text-red-700 border-red-200';
     case 'not_requested':
     case 'not-requested':
       return 'bg-gray-100 text-gray-700 border-gray-200';

--- a/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
+++ b/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
@@ -55,7 +55,7 @@ export const DocumentChecklist: Story = {
     const canvas = within(canvasElement);
     const rejectedRow = canvas.getByText('Employer Reference Letter').closest('.p-6');
 
-    if (!rejectedRow) {
+    if (!(rejectedRow instanceof HTMLElement)) {
       throw new Error('Expected rejected document row');
     }
 

--- a/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
+++ b/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
@@ -31,7 +31,6 @@ type Story = StoryObj<typeof meta>;
 
 const documentUploadSubmit = fn(async () => {});
 const reminderMarkRead = fn(async () => {});
-const reminderAcknowledge = fn(async () => {});
 
 export const CaseSummary: Story = {
   render: () => <CaseSummaryCard caseInfo={mockCaseInfo} />,
@@ -52,6 +51,23 @@ export const DocumentChecklist: Story = {
       downloadingDocumentId={null}
     />
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const rejectedRow = canvas.getByText('Employer Reference Letter').closest('.p-6');
+
+    if (!rejectedRow) {
+      throw new Error('Expected rejected document row');
+    }
+
+    const rejectedScope = within(rejectedRow);
+
+    await expect(canvas.getByText('Rejection Note')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Please upload a revised letter that includes salary and a full duties breakdown.')
+    ).toBeInTheDocument();
+    await expect(rejectedScope.queryByText('File: reference-letter.pdf')).not.toBeInTheDocument();
+    await expect(rejectedScope.queryByRole('button', { name: 'View' })).not.toBeInTheDocument();
+  },
 };
 
 export const DocumentUploadModal: Story = {
@@ -100,22 +116,16 @@ export const Reminders: Story = {
     <RemindersPanel
       recentReminders={mockDashboardReminders}
       allReminders={mockDashboardReminders}
-      canAcknowledgeReminders
       onMarkRead={reminderMarkRead}
-      onAcknowledge={reminderAcknowledge}
-      updatingReminderId={null}
     />
   ),
   play: async ({ canvasElement }) => {
     reminderMarkRead.mockClear();
-    reminderAcknowledge.mockClear();
     const canvas = within(canvasElement);
 
     await userEvent.click(canvas.getByRole('button', { name: /updated review status/i }));
     await expect(reminderMarkRead).toHaveBeenCalledWith('dash-reminder-1');
-
-    await userEvent.click(canvas.getByRole('button', { name: 'Acknowledge' }));
-    await expect(reminderAcknowledge).toHaveBeenCalledWith('dash-reminder-1');
+    await expect(canvas.queryByRole('button', { name: 'Acknowledge' })).not.toBeInTheDocument();
   },
 };
 

--- a/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
+++ b/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
@@ -132,6 +132,14 @@ export function DocumentChecklistPanel({
                       {document.instructions ? (
                         <p className="mt-2 text-xs text-gray-500">{document.instructions}</p>
                       ) : null}
+                      {document.rejectionNote ? (
+                        <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-red-700">
+                            Rejection Note
+                          </p>
+                          <p className="mt-1 text-sm text-red-700">{document.rejectionNote}</p>
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                   <div className="flex items-center gap-3">

--- a/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
+++ b/frontend/figma/components/client-dashboard/DocumentChecklistPanel.tsx
@@ -118,7 +118,6 @@ export function DocumentChecklistPanel({
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
                         <p className="font-medium text-gray-900">{document.name}</p>
-                        {document.required ? <span className="text-xs text-red-600 font-medium">*Required</span> : null}
                         <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 border border-gray-200">
                           {document.lawyerStatus}
                         </span>

--- a/frontend/figma/components/client-dashboard/RemindersPanel.tsx
+++ b/frontend/figma/components/client-dashboard/RemindersPanel.tsx
@@ -1,4 +1,4 @@
-import { BellRing, CheckCircle2, MailCheck, X } from 'lucide-react';
+import { BellRing, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { DashboardReminder } from './types';
@@ -6,19 +6,13 @@ import type { DashboardReminder } from './types';
 type RemindersPanelProps = {
   allReminders?: DashboardReminder[];
   recentReminders: DashboardReminder[];
-  canAcknowledgeReminders: boolean;
   onMarkRead: (reminderId: string) => Promise<void>;
-  onAcknowledge: (reminderId: string) => Promise<void>;
-  updatingReminderId: string | null;
 };
 
 export function RemindersPanel({
   allReminders,
   recentReminders,
-  canAcknowledgeReminders,
   onMarkRead,
-  onAcknowledge,
-  updatingReminderId,
 }: RemindersPanelProps) {
   const [selectedReminderId, setSelectedReminderId] = useState<string | null>(null);
   const [isBoardOpen, setIsBoardOpen] = useState(false);
@@ -86,15 +80,9 @@ export function RemindersPanel({
           ))}
         </div>
         <div className="p-4 border-t border-gray-200">
-          <div
-            className={`w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 ${
-              canAcknowledgeReminders
-                ? 'bg-red-50 text-red-700 border border-red-200'
-                : 'bg-gray-200 text-gray-500'
-            }`}
-          >
+          <div className="w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-red-50 text-red-700 border border-red-200">
             <BellRing className="w-4 h-4" />
-            {canAcknowledgeReminders ? 'lawyer reminders' : 'Reminder actions disabled'}
+            Laywer Reminders
           </div>
         </div>
       </div>
@@ -119,28 +107,6 @@ export function RemindersPanel({
             </div>
             <div className="px-5 py-4">
               <p className="text-sm text-gray-700 whitespace-pre-wrap">{selectedReminder.body}</p>
-              <div className="mt-4 flex items-center gap-2">
-                {selectedReminder.acknowledged ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">
-                    <MailCheck className="h-3 w-3" />
-                    Acknowledged
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void onAcknowledge(selectedReminder.id).catch(() => {
-                        // Handled by dashboard state; swallow to avoid unhandled promise rejections in UI handlers.
-                      });
-                    }}
-                    disabled={!canAcknowledgeReminders || updatingReminderId === selectedReminder.id}
-                    className="inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-                  >
-                    <CheckCircle2 className="h-3 w-3" />
-                    {updatingReminderId === selectedReminder.id ? 'Saving...' : 'Acknowledge'}
-                  </button>
-                )}
-              </div>
             </div>
           </div>
         </div>

--- a/frontend/figma/components/client-dashboard/types.ts
+++ b/frontend/figma/components/client-dashboard/types.ts
@@ -5,6 +5,7 @@ export type DashboardDocument = {
   name: string;
   status: DashboardDocumentStatus;
   lawyerStatus: string;
+  rejectionNote: string | null;
   uploadedDate: string;
   required: boolean;
   instructions: string | null;

--- a/frontend/figma/components/client-dashboard/useClientDashboardData.ts
+++ b/frontend/figma/components/client-dashboard/useClientDashboardData.ts
@@ -315,17 +315,22 @@ export function useClientDashboardData(): ClientDashboardData {
       return [];
     }
 
-    return workspace.documents.map((document) => ({
-      id: document.id,
-      name: document.name,
-      status: documentDisplayStatus(document.status, document.required),
-      lawyerStatus: titleize(document.status),
-      uploadedDate: formatDate(document.uploaded_at),
-      required: document.required,
-      instructions: document.instructions,
-      fileName: document.file_name,
-      canDownload: document.can_download,
-    }));
+    return workspace.documents.map((document) => {
+      const isRejected = document.status === 'rejected';
+
+      return {
+        id: document.id,
+        name: document.name,
+        status: documentDisplayStatus(document.status, document.required),
+        lawyerStatus: titleize(document.status),
+        rejectionNote: document.rejection_note ?? null,
+        uploadedDate: isRejected ? 'Not set' : formatDate(document.uploaded_at),
+        required: document.required,
+        instructions: document.instructions,
+        fileName: isRejected ? null : document.file_name,
+        canDownload: isRejected ? false : document.can_download,
+      };
+    });
   }, [workspace, capabilities.canViewDocuments]);
 
   const uploadDocument = async (

--- a/frontend/figma/storybook/fixtures.ts
+++ b/frontend/figma/storybook/fixtures.ts
@@ -192,7 +192,7 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-passport',
           name: 'Passport Biographical Page',
           required: true,
-          status: 'approved',
+          status: 'accepted',
           due_date: '2026-03-01',
           uploaded_at: '2026-02-12T14:00:00Z',
           instructions: 'Upload a clear color scan of the main passport page.',
@@ -224,10 +224,11 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-reference',
           name: 'Employer Reference Letter',
           required: true,
-          status: 'needs_revision',
+          status: 'rejected',
           due_date: '2026-03-05',
           uploaded_at: '2026-02-19T16:30:00Z',
           instructions: 'Must include duties, salary, and duration.',
+          rejection_note: 'Please upload a revised letter that includes salary and a full duties breakdown.',
           file_name: 'reference-letter.pdf',
           latest_case_document_id: 'case-doc-reference',
           can_download: true,
@@ -256,7 +257,7 @@ export const mockCaseWorkspace: CaseWorkspace = {
           id: 'doc-travel-history',
           name: 'Travel History Summary',
           required: false,
-          status: 'pending',
+          status: 'requested',
           due_date: '2026-03-10',
           uploaded_at: null,
           instructions: 'Provide a list of trips taken in the last 10 years.',
@@ -491,29 +492,34 @@ export const mockActivityItems: ActivityItem[] = [
 
 export const mockDashboardDocuments: DashboardDocument[] = mockCaseWorkspace.documents
   .filter((document) => document.status !== 'not_requested')
-  .map((document) => ({
-    id: document.id,
-    name: document.name,
-    status:
-      document.status === 'approved'
-        ? 'completed'
-        : document.status === 'received' || document.status === 'under_review'
-          ? 'review'
-          : document.required
-            ? 'pending'
-            : 'optional',
-    lawyerStatus: document.status
-      .replaceAll('_', ' ')
-      .split(' ')
-      .filter(Boolean)
-      .map((part) => part[0].toUpperCase() + part.slice(1))
-      .join(' '),
-    uploadedDate: document.uploaded_at ?? 'Pending',
-    required: document.required,
-    instructions: document.instructions,
-    fileName: document.file_name,
-    canDownload: document.can_download,
-  }));
+  .map((document) => {
+    const isRejected = document.status === 'rejected';
+
+    return {
+      id: document.id,
+      name: document.name,
+      status:
+        document.status === 'accepted' || document.status === 'approved'
+          ? 'completed'
+          : document.status === 'received' || document.status === 'under_review'
+            ? 'review'
+            : document.required
+              ? 'pending'
+              : 'optional',
+      lawyerStatus: document.status
+        .replaceAll('_', ' ')
+        .split(' ')
+        .filter(Boolean)
+        .map((part) => part[0].toUpperCase() + part.slice(1))
+        .join(' '),
+      rejectionNote: document.rejection_note ?? null,
+      uploadedDate: isRejected ? 'Not set' : (document.uploaded_at ?? 'Pending'),
+      required: document.required,
+      instructions: document.instructions,
+      fileName: isRejected ? null : document.file_name,
+      canDownload: isRejected ? false : document.can_download,
+    };
+  });
 
 export const mockDashboardMilestones: DashboardMilestone[] = [
   { title: 'Collect supporting documents', status: 'completed', date: 'Feb 24, 2026', description: 'Identity and employment package completed.' },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -288,6 +288,7 @@ export type CaseWorkspace = {
       uploaded_at: string | null;
       instructions: string | null;
       client_note?: string | null;
+      rejection_note?: string | null;
       file_name: string | null;
       latest_case_document_id: string | null;
       can_download: boolean;
@@ -302,6 +303,7 @@ export type CaseWorkspace = {
     uploaded_at: string | null;
     instructions: string | null;
     client_note?: string | null;
+    rejection_note?: string | null;
     file_name: string | null;
     latest_case_document_id: string | null;
     can_download: boolean;
@@ -377,6 +379,7 @@ export type CaseDocumentStatus =
   | 'requested'
   | 'received'
   | 'accepted'
+  | 'rejected'
   | 'not_requested';
 
 export type CaseDetailsUpdateInput = {
@@ -1027,13 +1030,14 @@ export async function createCaseCustomDocumentSuite(
 export async function updateCaseDocumentStatus(
   caseNumber: string,
   documentId: string,
-  status: CaseDocumentStatus
-): Promise<{ document_id: string; status: CaseDocumentStatus }> {
-  return requestJson<{ document_id: string; status: CaseDocumentStatus }>(
+  status: CaseDocumentStatus,
+  rejectionNote?: string | null
+): Promise<{ document_id: string; status: CaseDocumentStatus; rejection_note?: string | null }> {
+  return requestJson<{ document_id: string; status: CaseDocumentStatus; rejection_note?: string | null }>(
     `/api/v1/cases/by-number/${encodeURIComponent(caseNumber)}/documents/${encodeURIComponent(documentId)}/status`,
     {
       method: 'PATCH',
-      body: JSON.stringify({ status }),
+      body: JSON.stringify({ status, rejection_note: rejectionNote ?? null }),
     }
   );
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -151,7 +151,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -472,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -513,7 +511,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3088,6 +3085,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3177,7 +3175,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3283,7 +3282,6 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3294,7 +3292,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3305,7 +3302,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3362,7 +3358,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4046,7 +4041,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4376,7 +4370,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4464,7 +4457,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4881,6 +4873,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4913,7 +4906,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5169,7 +5163,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5247,7 +5240,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5433,7 +5425,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6892,7 +6883,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7364,6 +7354,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8000,6 +7991,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8015,6 +8007,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8027,7 +8020,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8077,7 +8071,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8132,7 +8125,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8303,7 +8295,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8737,7 +8728,6 @@
       "integrity": "sha512-P7K/b+Pn1sXJzwYCF6hH5Zjdrg4ZlA5Bz9rdOJEdvm6ev27XESDGI+Ql+dfUfUcGOym3Aud4MssJIDEF2ocsyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -9169,7 +9159,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9429,7 +9418,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9607,7 +9595,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10247,7 +10234,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10795,7 +10781,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
# Pull Request
Summary:
Updated the client reminder label in the dashboard.
Documents that the lawyer requests after the initial requests will now have their status automatically update.
Added lawyer-side Rejected document status with required rejection notes.
Displayed rejection notes on the client side and made rejected uploads appear cleared from the client view while preserving the backend record.
Made manually requested client uploads switch to received automatically after upload.
Removed the client reminder acknowledge action for the one-way lawyer-to-client message flow.
Removed the unused lawyer document action icon and added hover labels for rename/delete actions.

User impact:
Clients see cleaner reminder and document UI with clearer rejection guidance.
Rejected files now prompt replacement without looking like an active client upload.
Lawyers can reject documents with context and manage document actions with clearer controls.

Technical details:
Updated client dashboard document mapping and reminder panel behavior.
Updated lawyer document request actions and reject-note flow.
Adjusted backend case document status/upload logic for requested custom documents and rejection handling.
Expanded Storybook and backend route tests to cover the new behavior.