### PR TITLE
Update dashboard placeholders and client case details

### DIFF
--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -889,7 +889,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
         <RemindersSection
           key={workspace.case.case_number}
           workspace={workspace}
-          caseNumber={workspace.case.case_number}
           creating={isCreatingReminder}
           onCreateReminder={handleCreateReminder}
           onNotify={(message) => showNotice('info', message)}

--- a/frontend/figma/components/ClientDashboard.tsx
+++ b/frontend/figma/components/ClientDashboard.tsx
@@ -1,5 +1,4 @@
 import { AppointmentsPanel } from './client-dashboard/AppointmentsPanel';
-import { BillingSummaryPanel } from './client-dashboard/BillingSummaryPanel';
 import { CaseSummaryCard } from './client-dashboard/CaseSummaryCard';
 import { DocumentChecklistPanel } from './client-dashboard/DocumentChecklistPanel';
 import { RemindersPanel } from './client-dashboard/RemindersPanel';
@@ -21,7 +20,6 @@ export function ClientDashboard() {
     allReminders,
     recentReminders,
     upcomingAppointments,
-    billingInfo,
     requiredDocuments,
     completedRequiredDocuments,
     capabilities,
@@ -51,8 +49,7 @@ export function ClientDashboard() {
     capabilities.canViewCaseStatus ||
     capabilities.canViewDocuments ||
     capabilities.canViewMilestones ||
-    capabilities.canViewReminders ||
-    capabilities.canViewBilling;
+    capabilities.canViewReminders;
   const firstName = workspace.case.client_name.trim().split(/\s+/)[0] || workspace.case.client_name;
 
   return (
@@ -139,7 +136,6 @@ export function ClientDashboard() {
             {capabilities.canViewMilestones ? (
               <AppointmentsPanel upcomingAppointments={upcomingAppointments} />
             ) : null}
-            {capabilities.canViewBilling ? <BillingSummaryPanel billingInfo={billingInfo} /> : null}
           </div>
           </div>
         ) : null}

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -156,7 +156,6 @@ export const Reminders: Story = {
   render: () => (
     <RemindersSection
       workspace={mockCaseWorkspace}
-      caseNumber="C-2026-001"
       creating={false}
       onCreateReminder={createReminder}
       onNotify={notifyReminder}

--- a/frontend/figma/components/case-configuration/sections/CaseDetailsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/CaseDetailsSection.tsx
@@ -167,7 +167,7 @@ export function CaseDetailsSection({ workspace, saving, onSave, onNotify }: Case
         <div className="mt-6">
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Client-Facing Description
-            <span className="text-gray-500 font-normal ml-1">(visible to client)</span>
+            <span className="text-gray-500 font-normal ml-1">(Visible to Client)</span>
           </label>
           <textarea
             rows={3}
@@ -180,7 +180,7 @@ export function CaseDetailsSection({ workspace, saving, onSave, onNotify }: Case
         <div className="mt-4">
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Internal Notes
-            <span className="text-gray-500 font-normal ml-1">(lawyer only)</span>
+            <span className="text-gray-500 font-normal ml-1">(Lawyer Only)</span>
           </label>
           <textarea
             rows={3}

--- a/frontend/figma/components/case-configuration/sections/MilestonesSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/MilestonesSection.tsx
@@ -146,6 +146,8 @@ export function MilestonesSection({
                           <div className="flex items-center gap-2">
                             <button
                               className="p-1 hover:bg-white rounded disabled:opacity-50"
+                              title={milestone.client_visible ? 'Hide from Client' : 'Show to Client'}
+                              aria-label={milestone.client_visible ? 'Hide from Client' : 'Show to Client'}
                               disabled={isUpdating}
                               onClick={(event) => {
                                 event.stopPropagation();
@@ -162,6 +164,8 @@ export function MilestonesSection({
                             </button>
                             <button
                               className="p-1 hover:bg-white rounded disabled:opacity-50"
+                              title="Edit Milestone"
+                              aria-label="Edit Milestone"
                               disabled={isUpdating}
                               onClick={(event) => {
                                 event.stopPropagation();
@@ -172,6 +176,8 @@ export function MilestonesSection({
                             </button>
                             <button
                               className="p-1 hover:bg-white rounded disabled:opacity-50"
+                              title="Delete Milestone"
+                              aria-label="Delete Milestone"
                               disabled={isUpdating}
                               onClick={(event) => {
                                 event.stopPropagation();

--- a/frontend/figma/components/case-configuration/sections/PaymentsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/PaymentsSection.tsx
@@ -1,97 +1,26 @@
 import { Info } from 'lucide-react';
 
-import type { CaseWorkspace } from '@/lib/api';
-
-import { formatDate } from '../utils';
-
 type PaymentsSectionProps = {
-  workspace: CaseWorkspace;
+  workspace: unknown;
 };
 
-export function PaymentsSection({ workspace }: PaymentsSectionProps) {
-  const paid = workspace.payment_items.reduce((sum, payment) => sum + payment.amount_paid, 0);
-  const pending = workspace.payment_items.reduce((sum, payment) => sum + payment.amount_due, 0);
-  const total = workspace.payment_items.reduce((sum, payment) => sum + payment.amount, 0);
-  const formatCurrency = (value: number) =>
-    new Intl.NumberFormat('en-CA', {
-      style: 'currency',
-      currency: 'CAD',
-      maximumFractionDigits: 2,
-    }).format(value);
-
+export function PaymentsSection({ workspace: _workspace }: PaymentsSectionProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold text-gray-900 mb-2">Payments & Invoices</h2>
-          <p className="text-gray-600">Payment summary and invoice history</p>
+          <p className="text-gray-600">Payment and invoice tools are temporarily hidden</p>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-          <div className="text-2xl font-bold text-green-700">{formatCurrency(paid)}</div>
-          <div className="text-sm text-green-600">Total Paid</div>
-        </div>
-        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-          <div className="text-2xl font-bold text-yellow-700">{formatCurrency(pending)}</div>
-          <div className="text-sm text-yellow-600">Pending Payment</div>
-        </div>
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <div className="text-2xl font-bold text-gray-700">{formatCurrency(total)}</div>
-          <div className="text-sm text-gray-600">Total Amount</div>
-        </div>
-      </div>
-
-      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Description</th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Amount</th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Status</th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Due Date</th>
-              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Invoice</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {workspace.payment_items.map((payment) => (
-              <tr key={payment.id} className="hover:bg-gray-50">
-                <td className="px-6 py-4">
-                  <div className="font-medium text-gray-900">{payment.description}</div>
-                  {payment.paid_date ? <div className="text-xs text-gray-500 mt-0.5">Paid: {formatDate(payment.paid_date)}</div> : null}
-                </td>
-                <td className="px-6 py-4 font-semibold text-gray-900">{formatCurrency(payment.amount)}</td>
-                <td className="px-6 py-4">
-                  <span
-                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                      payment.amount_due <= 0 ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
-                    }`}
-                  >
-                    {payment.amount_due <= 0 ? 'Paid' : 'Pending'}
-                  </span>
-                </td>
-                <td className="px-6 py-4 text-sm text-gray-600">{formatDate(payment.due_date)}</td>
-                <td className="px-6 py-4">
-                  {payment.invoice_number ? (
-                    <span className="text-sm text-blue-600 hover:underline cursor-pointer">{payment.invoice_number}</span>
-                  ) : (
-                    <span className="text-sm text-gray-400">-</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+      <div className="bg-white border border-gray-200 rounded-lg p-8">
         <div className="flex gap-3">
           <Info className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
           <div>
-            <p className="text-sm font-medium text-blue-900">Compliance Snapshot</p>
-            <p className="text-sm text-blue-700 mt-1">
-              Total fees: {formatCurrency(workspace.billing_summary.total_fees)} | Remaining: {formatCurrency(workspace.billing_summary.remaining)} | Payment method: {workspace.billing_summary.payment_method ?? 'Not set'}
+            <p className="text-lg font-semibold text-gray-900">Coming Soon</p>
+            <p className="mt-2 text-sm text-gray-600">
+              Payments and invoice management are not available yet. This section will be enabled in a later update.
             </p>
           </div>
         </div>

--- a/frontend/figma/components/case-configuration/sections/RemindersSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/RemindersSection.tsx
@@ -13,7 +13,6 @@ type OutboundReminder = {
 
 type RemindersSectionProps = {
   workspace: CaseWorkspace;
-  caseNumber: string;
   creating: boolean;
   onCreateReminder: (reminder: OutboundReminder) => Promise<boolean>;
   onNotify: (message: string) => void;
@@ -48,43 +47,11 @@ const templates: TemplateOption[] = [
   },
 ];
 
-function readDraft(storageKey: string): { templateLabel: string; title: string; body: string; sendEmail: boolean } {
-  if (typeof window === 'undefined') {
-    return { templateLabel: '', title: '', body: '', sendEmail: false };
-  }
-
-  try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) {
-      return { templateLabel: '', title: '', body: '', sendEmail: false };
-    }
-
-    const parsed = JSON.parse(raw) as { templateLabel?: string; title?: string; body?: string; sendEmail?: boolean };
-    return {
-      templateLabel: parsed.templateLabel ?? '',
-      title: parsed.title ?? '',
-      body: parsed.body ?? '',
-      sendEmail: Boolean(parsed.sendEmail),
-    };
-  } catch {
-    return { templateLabel: '', title: '', body: '', sendEmail: false };
-  }
-}
-
-export function RemindersSection({ workspace, caseNumber, creating, onCreateReminder, onNotify }: RemindersSectionProps) {
+export function RemindersSection({ workspace, creating, onCreateReminder, onNotify }: RemindersSectionProps) {
   const recentReminders = workspace.reminders.slice(0, 8);
-  const draftStorageKey = `visatrack-reminder-draft-${caseNumber}`;
-  const initialDraft = readDraft(draftStorageKey);
-  const [templateLabel, setTemplateLabel] = useState(initialDraft.templateLabel);
-  const [title, setTitle] = useState(initialDraft.title);
-  const [body, setBody] = useState(initialDraft.body);
-  const [sendEmail, setSendEmail] = useState(initialDraft.sendEmail);
-
-  const saveDraft = () => {
-    const draft = JSON.stringify({ templateLabel, title, body, sendEmail });
-    localStorage.setItem(draftStorageKey, draft);
-    onNotify('Draft saved locally.');
-  };
+  const [templateLabel, setTemplateLabel] = useState('');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
 
   const handleTemplateChange = (nextLabel: string) => {
     setTemplateLabel(nextLabel);
@@ -107,7 +74,7 @@ export function RemindersSection({ workspace, caseNumber, creating, onCreateRemi
     const success = await onCreateReminder({
       title: normalizedTitle,
       body: normalizedBody,
-      sendEmail,
+      sendEmail: false,
     });
     if (!success) {
       return;
@@ -116,8 +83,6 @@ export function RemindersSection({ workspace, caseNumber, creating, onCreateRemi
     setTemplateLabel('');
     setTitle('');
     setBody('');
-    setSendEmail(false);
-    localStorage.removeItem(draftStorageKey);
   };
 
   return (
@@ -179,18 +144,6 @@ export function RemindersSection({ workspace, caseNumber, creating, onCreateRemi
             <Send className="w-4 h-4" />
             {creating ? 'Posting...' : 'Post Reminder'}
           </button>
-          <button className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors" onClick={saveDraft}>
-            Save as Draft
-          </button>
-          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
-            <input
-              type="checkbox"
-              className="rounded border-gray-300"
-              checked={sendEmail}
-              onChange={(event) => setSendEmail(event.target.checked)}
-            />
-            Send email notification
-          </label>
         </div>
       </div>
 

--- a/frontend/figma/components/case-configuration/utils.ts
+++ b/frontend/figma/components/case-configuration/utils.ts
@@ -1,9 +1,27 @@
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDisplayDate(value: string): Date {
+  if (DATE_ONLY_PATTERN.test(value)) {
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  return new Date(value);
+}
+
+function formatDateParts(value: Date): string {
+  const year = value.getFullYear();
+  const month = `${value.getMonth() + 1}`.padStart(2, '0');
+  const day = `${value.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export function formatDate(value: string | null | undefined): string {
   if (!value) {
     return 'Not set';
   }
 
-  return new Date(value).toLocaleDateString('en-US', {
+  return parseDisplayDate(value).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -15,7 +33,11 @@ export function formatDateInput(value: string | null | undefined): string {
     return '';
   }
 
-  return new Date(value).toISOString().slice(0, 10);
+  if (DATE_ONLY_PATTERN.test(value)) {
+    return value;
+  }
+
+  return formatDateParts(parseDisplayDate(value));
 }
 
 export function formatDateTime(value: string | null | undefined): string {

--- a/frontend/figma/components/client-dashboard/CaseSummaryCard.tsx
+++ b/frontend/figma/components/client-dashboard/CaseSummaryCard.tsx
@@ -31,6 +31,13 @@ export function CaseSummaryCard({ caseInfo }: CaseSummaryCardProps) {
           <p className="font-medium text-gray-900">{caseInfo.estimatedCompletion}</p>
         </div>
       </div>
+
+      {caseInfo.description ? (
+        <div className="border-t border-gray-200 pt-6">
+          <p className="text-sm text-gray-600 mb-2">Case Description</p>
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{caseInfo.description}</p>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
+++ b/frontend/figma/components/client-dashboard/ClientDashboardComponents.stories.tsx
@@ -34,6 +34,13 @@ const reminderMarkRead = fn(async () => {});
 
 export const CaseSummary: Story = {
   render: () => <CaseSummaryCard caseInfo={mockCaseInfo} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByText('We are currently preparing your case package and reviewing the remaining supporting evidence before submission.')
+    ).toBeInTheDocument();
+  },
 };
 
 export const DocumentChecklist: Story = {

--- a/frontend/figma/components/client-dashboard/types.ts
+++ b/frontend/figma/components/client-dashboard/types.ts
@@ -53,6 +53,7 @@ export type CaseInfo = {
   assignedLawyer: string;
   startDate: string;
   estimatedCompletion: string;
+  description: string | null;
 };
 
 export type ClientPortalCapabilities = {

--- a/frontend/figma/components/client-dashboard/useClientDashboardData.ts
+++ b/frontend/figma/components/client-dashboard/useClientDashboardData.ts
@@ -307,6 +307,7 @@ export function useClientDashboardData(): ClientDashboardData {
       assignedLawyer: workspace.case.primary_lawyer_name ?? 'Unassigned',
       startDate: formatDate(workspace.case.start_date),
       estimatedCompletion,
+      description: workspace.case.description ?? null,
     };
   }, [workspace, capabilities.canViewCaseStatus]);
 

--- a/frontend/figma/components/client-dashboard/utils.ts
+++ b/frontend/figma/components/client-dashboard/utils.ts
@@ -1,11 +1,22 @@
 import type { DashboardDocumentStatus } from './types';
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDisplayDate(value: string): Date {
+  if (DATE_ONLY_PATTERN.test(value)) {
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  return new Date(value);
+}
+
 export function formatDate(value: string | null | undefined): string {
   if (!value) {
     return 'Not set';
   }
 
-  return new Date(value).toLocaleDateString('en-US', {
+  return parseDisplayDate(value).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/frontend/figma/storybook/fixtures.ts
+++ b/frontend/figma/storybook/fixtures.ts
@@ -571,6 +571,7 @@ export const mockCaseInfo: CaseInfo = {
   assignedLawyer: 'Avery Counsel',
   startDate: 'Feb 10, 2026',
   estimatedCompletion: 'Jun 1, 2026 - Aug 15, 2026',
+  description: 'We are currently preparing your case package and reviewing the remaining supporting evidence before submission.',
 };
 
 export const mockOrganizations: OrganizationListItem[] = [


### PR DESCRIPTION
Summary:
Removed the client billing section.
Simplified lawyer reminders, got rid of "send e-mail notification" and "save as draft".
Fixed client-facing case description to the client dashboard.
Updated case details helper text capitalization.
Replaced the lawyer payments/invoices screen with a coming soon placeholder.
Fixed milestones calander issue where after picking a date in calander the dahsboard displays a different date.

User impact:
Clients see the lawyer’s case description properly.
Unused billing/payment UI is hidden for now.
Lawyers get a simpler reminders flow.
User see the correct date for milestones

Validation performed:
Frontend Storybook tests passed for the client-side changes.

Closes #134
Closes #133
Closes #130
Closes #131