### PR TITLE
Consolidate portal permissions UI and harden client-side permission behavior

### DIFF
--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -753,13 +753,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     }
   };
 
-  const handlePortalPermissionsChange = (nextPermissions: CasePortalPermissions) => {
-    updateWorkspace((current) => ({
-      ...current,
-      portal_permissions: normalizePortalPermissions(nextPermissions),
-    }));
-  };
-
   const handleResetPortalPermissions = () => {
     updateWorkspace((current) => ({
       ...current,
@@ -768,16 +761,18 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
     showNotice('info', 'Portal permissions reset to default values.');
   };
 
-  const handleSavePortalPermissions = async () => {
+  const handleSavePortalPermissions = async (
+    nextPermissions: CasePortalPermissions
+  ): Promise<boolean> => {
     if (!workspace) {
-      return;
+      return false;
     }
 
     setIsSavingPermissions(true);
     try {
       const savedPermissions = await updateCasePortalPermissions(
         workspace.case.case_number,
-        normalizePortalPermissions(workspace.portal_permissions)
+        normalizePortalPermissions(nextPermissions)
       );
 
       updateWorkspace((current) => ({
@@ -786,9 +781,11 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       }));
 
       showNotice('success', 'Client portal visibility updated.');
+      return true;
     } catch (saveError) {
       const message = saveError instanceof Error ? saveError.message : 'Unknown error';
       showNotice('error', `Failed to save permissions: ${message}`);
+      return false;
     } finally {
       setIsSavingPermissions(false);
     }
@@ -901,8 +898,8 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
       <PermissionsSection
         workspace={workspace}
         portalPermissions={normalizePortalPermissions(workspace.portal_permissions)}
+        defaultPortalPermissions={DEFAULT_PORTAL_PERMISSIONS}
         saving={isSavingPermissions}
-        onChange={handlePortalPermissionsChange}
         onReset={handleResetPortalPermissions}
         onSave={handleSavePortalPermissions}
       />

--- a/frontend/figma/components/CaseConfiguration.tsx
+++ b/frontend/figma/components/CaseConfiguration.tsx
@@ -896,7 +896,6 @@ export function CaseConfiguration({ caseId, onBack }: CaseConfigurationProps) {
 
     return (
       <PermissionsSection
-        workspace={workspace}
         portalPermissions={normalizePortalPermissions(workspace.portal_permissions)}
         defaultPortalPermissions={DEFAULT_PORTAL_PERMISSIONS}
         saving={isSavingPermissions}

--- a/frontend/figma/components/TopLevel.stories.tsx
+++ b/frontend/figma/components/TopLevel.stories.tsx
@@ -92,7 +92,7 @@ export const CaseConfigurationPage: Story = {
     });
 
     await userEvent.click(canvas.getByRole('button', { name: 'Sharing / Permissions' }));
-    await expect(await canvas.findByRole('heading', { name: 'Client Portal Visibility' })).toBeInTheDocument();
+    await expect(await canvas.findByRole('heading', { name: 'Access Control' })).toBeInTheDocument();
   },
 };
 

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -193,10 +193,10 @@ export const Permissions: Story = {
     <PermissionsSection
       workspace={mockCaseWorkspace}
       portalPermissions={mockPortalPermissions}
+      defaultPortalPermissions={mockPortalPermissions}
       saving={false}
-      onChange={() => {}}
       onReset={() => {}}
-      onSave={() => {}}
+      onSave={async () => true}
     />
   ),
 };

--- a/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
+++ b/frontend/figma/components/case-configuration/CaseConfigurationSections.stories.tsx
@@ -191,7 +191,6 @@ export const Reminders: Story = {
 export const Permissions: Story = {
   render: () => (
     <PermissionsSection
-      workspace={mockCaseWorkspace}
       portalPermissions={mockPortalPermissions}
       defaultPortalPermissions={mockPortalPermissions}
       saving={false}

--- a/frontend/figma/components/case-configuration/sections/PermissionsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/PermissionsSection.tsx
@@ -1,27 +1,42 @@
 import { AlertCircle, Save } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import type { CasePortalPermissions, CaseWorkspace } from '@/lib/api';
-
-import { formatDate, titleize } from '../utils';
 
 type PermissionsSectionProps = {
   workspace: CaseWorkspace;
   portalPermissions: CasePortalPermissions;
+  defaultPortalPermissions: CasePortalPermissions;
   saving: boolean;
-  onChange: (next: CasePortalPermissions) => void;
   onReset: () => void;
-  onSave: () => void;
+  onSave: (next: CasePortalPermissions) => Promise<boolean>;
 };
+
+function hasPermissionChanges(
+  current: CasePortalPermissions,
+  baseline: CasePortalPermissions
+): boolean {
+  return (
+    current.show_case_status_progress !== baseline.show_case_status_progress ||
+    current.show_milestone_details !== baseline.show_milestone_details ||
+    current.show_document_requirements !== baseline.show_document_requirements ||
+    current.portal_access !== baseline.portal_access ||
+    current.document_upload !== baseline.document_upload ||
+    current.reminders !== baseline.reminders
+  );
+}
 
 function VisibilityRow({
   title,
   description,
   enabled,
+  disabled,
   onToggle,
 }: {
   title: string;
   description: string;
   enabled: boolean;
+  disabled: boolean;
   onToggle: () => void;
 }) {
   return (
@@ -33,11 +48,12 @@ function VisibilityRow({
       <button
         type="button"
         onClick={onToggle}
+        disabled={disabled}
         className={`px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors ${
           enabled
             ? 'bg-green-100 text-green-700 border-green-300 hover:bg-green-200'
             : 'bg-gray-200 text-gray-700 border-gray-300 hover:bg-gray-300'
-        }`}
+        } disabled:opacity-60 disabled:cursor-not-allowed`}
       >
         {enabled ? 'Enabled' : 'Disabled'}
       </button>
@@ -48,11 +64,46 @@ function VisibilityRow({
 export function PermissionsSection({
   workspace,
   portalPermissions,
+  defaultPortalPermissions,
   saving,
-  onChange,
   onReset,
   onSave,
 }: PermissionsSectionProps) {
+  const [draftPermissions, setDraftPermissions] = useState<CasePortalPermissions>(portalPermissions);
+
+  useEffect(() => {
+    setDraftPermissions((current) =>
+      hasPermissionChanges(current, portalPermissions) ? current : portalPermissions
+    );
+  }, [portalPermissions]);
+
+  const isDisabled = saving;
+  const hasUnsavedChanges = hasPermissionChanges(draftPermissions, portalPermissions);
+
+  const handleResetToDefault = () => {
+    if (saving) {
+      return;
+    }
+
+    setDraftPermissions(defaultPortalPermissions);
+    onReset();
+  };
+
+  const handleSave = async () => {
+    await onSave(draftPermissions);
+  };
+
+  const toggleVisibility = (key: keyof Pick<CasePortalPermissions, 'show_case_status_progress' | 'show_milestone_details' | 'show_document_requirements'>) => {
+    if (isDisabled) {
+      return;
+    }
+
+    setDraftPermissions((previous) => ({
+      ...previous,
+      [key]: !previous[key],
+    }));
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -61,90 +112,33 @@ export function PermissionsSection({
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="font-semibold text-gray-900 mb-4">Active Case Assignments</h3>
-        <div className="space-y-3">
-          {workspace.assignments.map((assignment) => (
-            <div key={assignment.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-              <div>
-                <div className="font-medium text-gray-900">{assignment.member_name}</div>
-                <div className="text-sm text-gray-600">Role: {titleize(assignment.role)}</div>
-              </div>
-              <div className="text-xs text-gray-500">Assigned {formatDate(assignment.assigned_at)}</div>
-            </div>
-          ))}
-          {workspace.assignments.length === 0 ? <p className="text-sm text-gray-500">No active assignments found for this case.</p> : null}
-        </div>
-      </div>
-
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <h3 className="font-semibold text-gray-900 mb-4">Client Portal Visibility</h3>
-
-        <div className="space-y-4">
-          <VisibilityRow
-            title="Case Status & Progress"
-            description="Show current status and completion percentage"
-            enabled={portalPermissions.show_case_status_progress}
-            onToggle={() =>
-              onChange({
-                ...portalPermissions,
-                show_case_status_progress: !portalPermissions.show_case_status_progress,
-              })
-            }
-          />
-
-          <VisibilityRow
-            title="Milestone Details"
-            description="Show milestone descriptions and due dates"
-            enabled={portalPermissions.show_milestone_details}
-            onToggle={() =>
-              onChange({
-                ...portalPermissions,
-                show_milestone_details: !portalPermissions.show_milestone_details,
-              })
-            }
-          />
-
-          <VisibilityRow
-            title="Document Requirements"
-            description="Show required and optional document list"
-            enabled={portalPermissions.show_document_requirements}
-            onToggle={() =>
-              onChange({
-                ...portalPermissions,
-                show_document_requirements: !portalPermissions.show_document_requirements,
-              })
-            }
-          />
-
-          <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-200">
-            <div>
-              <div className="font-medium text-gray-900">Internal Notes</div>
-              <div className="text-sm text-gray-600">Lawyer-only notes (never visible to client)</div>
-            </div>
-            <div className="text-sm text-red-700 font-medium">Disabled</div>
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
         <h3 className="font-semibold text-gray-900 mb-4">Access Control</h3>
+
+        <div className="mb-4 text-sm">
+          {hasUnsavedChanges ? (
+            <p className="text-amber-700">Unsaved changes. Click “Save Permissions” to apply them.</p>
+          ) : (
+            <p className="text-gray-600">Changes here are editable by default.</p>
+          )}
+        </div>
 
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Client Portal Access</label>
             <select
-              value={portalPermissions.portal_access}
+              value={draftPermissions.portal_access}
               onChange={(event) =>
-                onChange({
-                  ...portalPermissions,
+                setDraftPermissions((previous) => ({
+                  ...previous,
                   portal_access: event.target.value as CasePortalPermissions['portal_access'],
-                })
+                }))
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500"
+              disabled={isDisabled}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
-              <option value="full_access">Full Access - Client can view all enabled sections</option>
-              <option value="limited_access">Limited Access - Client can only view documents and reminders</option>
-              <option value="read_only">Read Only - Client cannot upload or respond</option>
+              <option value="full_access">Full Access - Client can view all enabled sections (status, milestones, and checklist)</option>
+              <option value="limited_access">Limited Access - Client sees core updates only (checklist and reminders)</option>
+              <option value="read_only">Read Only - Client can view enabled information but cannot upload or respond</option>
               <option value="disabled">Disabled - Client portal access suspended</option>
             </select>
           </div>
@@ -152,14 +146,15 @@ export function PermissionsSection({
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Document Upload Permissions</label>
             <select
-              value={portalPermissions.document_upload}
+              value={draftPermissions.document_upload}
               onChange={(event) =>
-                onChange({
-                  ...portalPermissions,
+                setDraftPermissions((previous) => ({
+                  ...previous,
                   document_upload: event.target.value as CasePortalPermissions['document_upload'],
-                })
+                }))
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500"
+              disabled={isDisabled}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
               <option value="enabled">Enabled - Client can upload requested documents</option>
               <option value="disabled">Disabled - Document upload suspended</option>
@@ -169,34 +164,74 @@ export function PermissionsSection({
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Reminder Visibility</label>
             <select
-              value={portalPermissions.reminders}
+              value={draftPermissions.reminders}
               onChange={(event) =>
-                onChange({
-                  ...portalPermissions,
+                setDraftPermissions((previous) => ({
+                  ...previous,
                   reminders: event.target.value as CasePortalPermissions['reminders'],
-                })
+                }))
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500"
+              disabled={isDisabled}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
-              <option value="enabled">Enabled - Client can view lawyer reminders</option>
+              <option value="enabled">Enabled - Client can view case reminders</option>
               <option value="disabled">Disabled - Hide reminders from client portal</option>
             </select>
+          </div>
+
+          <div className="pt-2 border-t border-gray-200">
+            <h4 className="text-sm font-semibold text-gray-900 mb-3">Client Portal Visibility</h4>
+            <div className="space-y-4">
+              <VisibilityRow
+                title="Case Status"
+                description="Show the current case status to the client"
+                enabled={draftPermissions.show_case_status_progress}
+                disabled={isDisabled}
+                onToggle={() => toggleVisibility('show_case_status_progress')}
+              />
+
+              <VisibilityRow
+                title="Milestones"
+                description="Show milestone names, details, and due dates"
+                enabled={draftPermissions.show_milestone_details}
+                disabled={isDisabled}
+                onToggle={() => toggleVisibility('show_milestone_details')}
+              />
+
+              <VisibilityRow
+                title="Document Checklist"
+                description="Show required and optional document items"
+                enabled={draftPermissions.show_document_requirements}
+                disabled={isDisabled}
+                onToggle={() => toggleVisibility('show_document_requirements')}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-200">
+            <div>
+              <div className="font-medium text-gray-900">Internal Notes</div>
+              <div className="text-sm text-gray-600">Lawyer-only notes (never visible to client)</div>
+            </div>
+            <div className="text-sm text-red-700 font-medium">Disabled</div>
           </div>
         </div>
 
         <div className="mt-6 flex justify-end gap-3">
           <button
             type="button"
-            onClick={onReset}
-            disabled={saving}
+            onClick={handleResetToDefault}
+            disabled={isDisabled}
             className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-60"
           >
             Reset to Default
           </button>
           <button
             type="button"
-            onClick={onSave}
-            disabled={saving}
+            onClick={() => {
+              void handleSave();
+            }}
+            disabled={isDisabled}
             className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors flex items-center gap-2 disabled:opacity-60"
           >
             <Save className="w-4 h-4" />

--- a/frontend/figma/components/case-configuration/sections/PermissionsSection.tsx
+++ b/frontend/figma/components/case-configuration/sections/PermissionsSection.tsx
@@ -1,10 +1,9 @@
 import { AlertCircle, Save } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import type { CasePortalPermissions, CaseWorkspace } from '@/lib/api';
+import type { CasePortalPermissions } from '@/lib/api';
 
 type PermissionsSectionProps = {
-  workspace: CaseWorkspace;
   portalPermissions: CasePortalPermissions;
   defaultPortalPermissions: CasePortalPermissions;
   saving: boolean;
@@ -62,7 +61,6 @@ function VisibilityRow({
 }
 
 export function PermissionsSection({
-  workspace,
   portalPermissions,
   defaultPortalPermissions,
   saving,
@@ -70,15 +68,12 @@ export function PermissionsSection({
   onSave,
 }: PermissionsSectionProps) {
   const [draftPermissions, setDraftPermissions] = useState<CasePortalPermissions>(portalPermissions);
+  const [hasLocalChanges, setHasLocalChanges] = useState(false);
 
-  useEffect(() => {
-    setDraftPermissions((current) =>
-      hasPermissionChanges(current, portalPermissions) ? current : portalPermissions
-    );
-  }, [portalPermissions]);
+  const effectivePermissions = hasLocalChanges ? draftPermissions : portalPermissions;
 
   const isDisabled = saving;
-  const hasUnsavedChanges = hasPermissionChanges(draftPermissions, portalPermissions);
+  const hasUnsavedChanges = hasPermissionChanges(effectivePermissions, portalPermissions);
 
   const handleResetToDefault = () => {
     if (saving) {
@@ -86,11 +81,15 @@ export function PermissionsSection({
     }
 
     setDraftPermissions(defaultPortalPermissions);
+    setHasLocalChanges(true);
     onReset();
   };
 
   const handleSave = async () => {
-    await onSave(draftPermissions);
+    const success = await onSave(effectivePermissions);
+    if (success) {
+      setHasLocalChanges(false);
+    }
   };
 
   const toggleVisibility = (key: keyof Pick<CasePortalPermissions, 'show_case_status_progress' | 'show_milestone_details' | 'show_document_requirements'>) => {
@@ -98,10 +97,12 @@ export function PermissionsSection({
       return;
     }
 
+    const currentPermissions = hasLocalChanges ? draftPermissions : portalPermissions;
     setDraftPermissions((previous) => ({
-      ...previous,
-      [key]: !previous[key],
+      ...(hasLocalChanges ? previous : currentPermissions),
+      [key]: !currentPermissions[key],
     }));
+    setHasLocalChanges(true);
   };
 
   return (
@@ -126,13 +127,14 @@ export function PermissionsSection({
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Client Portal Access</label>
             <select
-              value={draftPermissions.portal_access}
-              onChange={(event) =>
+              value={effectivePermissions.portal_access}
+              onChange={(event) => {
                 setDraftPermissions((previous) => ({
-                  ...previous,
+                  ...(hasLocalChanges ? previous : portalPermissions),
                   portal_access: event.target.value as CasePortalPermissions['portal_access'],
-                }))
-              }
+                }));
+                setHasLocalChanges(true);
+              }}
               disabled={isDisabled}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
@@ -146,13 +148,14 @@ export function PermissionsSection({
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Document Upload Permissions</label>
             <select
-              value={draftPermissions.document_upload}
-              onChange={(event) =>
+              value={effectivePermissions.document_upload}
+              onChange={(event) => {
                 setDraftPermissions((previous) => ({
-                  ...previous,
+                  ...(hasLocalChanges ? previous : portalPermissions),
                   document_upload: event.target.value as CasePortalPermissions['document_upload'],
-                }))
-              }
+                }));
+                setHasLocalChanges(true);
+              }}
               disabled={isDisabled}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
@@ -164,13 +167,14 @@ export function PermissionsSection({
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Reminder Visibility</label>
             <select
-              value={draftPermissions.reminders}
-              onChange={(event) =>
+              value={effectivePermissions.reminders}
+              onChange={(event) => {
                 setDraftPermissions((previous) => ({
-                  ...previous,
+                  ...(hasLocalChanges ? previous : portalPermissions),
                   reminders: event.target.value as CasePortalPermissions['reminders'],
-                }))
-              }
+                }));
+                setHasLocalChanges(true);
+              }}
               disabled={isDisabled}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 disabled:bg-gray-100 disabled:text-gray-500"
             >
@@ -185,7 +189,7 @@ export function PermissionsSection({
               <VisibilityRow
                 title="Case Status"
                 description="Show the current case status to the client"
-                enabled={draftPermissions.show_case_status_progress}
+                enabled={effectivePermissions.show_case_status_progress}
                 disabled={isDisabled}
                 onToggle={() => toggleVisibility('show_case_status_progress')}
               />
@@ -193,7 +197,7 @@ export function PermissionsSection({
               <VisibilityRow
                 title="Milestones"
                 description="Show milestone names, details, and due dates"
-                enabled={draftPermissions.show_milestone_details}
+                enabled={effectivePermissions.show_milestone_details}
                 disabled={isDisabled}
                 onToggle={() => toggleVisibility('show_milestone_details')}
               />
@@ -201,7 +205,7 @@ export function PermissionsSection({
               <VisibilityRow
                 title="Document Checklist"
                 description="Show required and optional document items"
-                enabled={draftPermissions.show_document_requirements}
+                enabled={effectivePermissions.show_document_requirements}
                 disabled={isDisabled}
                 onToggle={() => toggleVisibility('show_document_requirements')}
               />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -151,6 +151,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -471,6 +472,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -511,6 +513,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3085,7 +3088,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3175,8 +3177,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3282,6 +3283,7 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3292,6 +3294,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3302,6 +3305,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3358,6 +3362,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4041,6 +4046,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4370,6 +4376,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4457,6 +4464,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4873,7 +4881,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4906,8 +4913,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5163,6 +5169,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5240,6 +5247,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5425,6 +5433,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6883,6 +6892,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7354,7 +7364,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7991,7 +8000,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8007,7 +8015,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8020,8 +8027,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8071,6 +8077,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8125,6 +8132,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8295,6 +8303,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8728,6 +8737,7 @@
       "integrity": "sha512-P7K/b+Pn1sXJzwYCF6hH5Zjdrg4ZlA5Bz9rdOJEdvm6ev27XESDGI+Ql+dfUfUcGOym3Aud4MssJIDEF2ocsyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -9159,6 +9169,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9418,6 +9429,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9595,6 +9607,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10234,6 +10247,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10781,6 +10795,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/tests/clientDashboard.permissions.test.tsx
+++ b/frontend/tests/clientDashboard.permissions.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ClientDashboard } from '../figma/components/ClientDashboard';
+import { mockCaseWorkspace, mockClientCases, mockPortalPermissions } from '../figma/storybook/fixtures';
+
+vi.mock('@/lib/api', () => ({
+  getClientCases: vi.fn(),
+  getCaseWorkspaceByNumber: vi.fn(),
+  markCaseReminderRead: vi.fn(async () => ({})),
+  acknowledgeCaseReminder: vi.fn(async () => ({})),
+  initiateCaseDocumentUpload: vi.fn(async () => ({})),
+  completeCaseDocumentUpload: vi.fn(async () => ({})),
+  deleteClientUploadedDocument: vi.fn(async () => undefined),
+  getCaseDocumentDownloadUrl: vi.fn(async () => ({ download_url: 'https://example.com/file', file_name: 'file.pdf' })),
+}));
+
+import { getCaseWorkspaceByNumber, getClientCases } from '@/lib/api';
+
+function makeWorkspaceWithPermissions(overrides: Partial<(typeof mockPortalPermissions)>) {
+  return {
+    ...JSON.parse(JSON.stringify(mockCaseWorkspace)),
+    portal_permissions: {
+      ...mockPortalPermissions,
+      ...overrides,
+    },
+  };
+}
+
+describe('ClientDashboard permission behavior', () => {
+  beforeEach(() => {
+    vi.mocked(getClientCases).mockResolvedValue(mockClientCases);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('hides detailed case status when show_case_status_progress is disabled', async () => {
+    vi.mocked(getCaseWorkspaceByNumber).mockResolvedValue(
+      makeWorkspaceWithPermissions({
+        portal_access: 'full_access',
+        show_case_status_progress: false,
+      })
+    );
+
+    render(<ClientDashboard />);
+
+    await screen.findByText('Case Overview');
+    expect(
+      screen.getByText('Your legal team has limited detailed case status visibility for this portal.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Case ID: C-2026-001')).not.toBeInTheDocument();
+  });
+
+  it('shows checklist/reminders but hides milestones and billing for limited access', async () => {
+    vi.mocked(getCaseWorkspaceByNumber).mockResolvedValue(
+      makeWorkspaceWithPermissions({
+        portal_access: 'limited_access',
+        show_case_status_progress: true,
+        show_document_requirements: true,
+        reminders: 'enabled',
+      })
+    );
+
+    render(<ClientDashboard />);
+
+    await screen.findByRole('heading', { name: 'Document Checklist' });
+    expect(screen.getByRole('heading', { name: 'Reminders' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Case Milestones' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Billing Summary' })).not.toBeInTheDocument();
+  });
+
+  it('disables document upload actions when document_upload is disabled', async () => {
+    vi.mocked(getCaseWorkspaceByNumber).mockResolvedValue(
+      makeWorkspaceWithPermissions({
+        portal_access: 'full_access',
+        show_document_requirements: true,
+        document_upload: 'disabled',
+      })
+    );
+
+    render(<ClientDashboard />);
+
+    await screen.findByRole('heading', { name: 'Document Checklist' });
+    const disabledUploadButtons = screen.getAllByRole('button', { name: 'Uploads Disabled' });
+    expect(disabledUploadButtons.length).toBeGreaterThan(0);
+    expect(disabledUploadButtons[0]).toBeDisabled();
+  });
+});

--- a/frontend/tests/permissionsSection.test.tsx
+++ b/frontend/tests/permissionsSection.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PermissionsSection } from '../figma/components/case-configuration/sections/PermissionsSection';
+import { mockCaseWorkspace, mockPortalPermissions } from '../figma/storybook/fixtures';
+
+function renderPermissionsSection(options?: {
+  portalPermissions?: typeof mockPortalPermissions;
+  onSave?: (next: typeof mockPortalPermissions) => Promise<boolean>;
+  onReset?: () => void;
+}) {
+  const onSave = options?.onSave ?? vi.fn(async () => true);
+  const onReset = options?.onReset ?? vi.fn();
+
+  const result = render(
+    <PermissionsSection
+      workspace={mockCaseWorkspace}
+      portalPermissions={options?.portalPermissions ?? mockPortalPermissions}
+      defaultPortalPermissions={mockPortalPermissions}
+      saving={false}
+      onReset={onReset}
+      onSave={onSave}
+    />
+  );
+
+  return {
+    ...result,
+    onSave,
+    onReset,
+  };
+}
+
+function getSelectForLabelText(labelText: string): HTMLSelectElement {
+  const label = screen.getByText(labelText);
+  const fieldContainer = label.parentElement;
+  if (!fieldContainer) {
+    throw new Error(`Missing field container for label: ${labelText}`);
+  }
+
+  const select = fieldContainer.querySelector('select');
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error(`Missing select for label: ${labelText}`);
+  }
+
+  return select;
+}
+
+describe('PermissionsSection', () => {
+  it('is editable by default and no longer requires edit mode', async () => {
+    renderPermissionsSection();
+
+    const portalAccessSelect = getSelectForLabelText('Client Portal Access');
+    expect(portalAccessSelect).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+
+    await userEvent.selectOptions(portalAccessSelect, 'read_only');
+    expect(portalAccessSelect).toHaveValue('read_only');
+  });
+
+  it('keeps unsaved local edits when portal permissions props refresh (polling)', async () => {
+    const { rerender } = renderPermissionsSection();
+
+    const portalAccessSelect = getSelectForLabelText('Client Portal Access');
+    await userEvent.selectOptions(portalAccessSelect, 'disabled');
+    expect(portalAccessSelect).toHaveValue('disabled');
+
+    rerender(
+      <PermissionsSection
+        workspace={mockCaseWorkspace}
+        portalPermissions={mockPortalPermissions}
+        defaultPortalPermissions={mockPortalPermissions}
+        saving={false}
+        onReset={() => {}}
+        onSave={async () => true}
+      />
+    );
+
+    expect(getSelectForLabelText('Client Portal Access')).toHaveValue('disabled');
+    expect(screen.getByText('Unsaved changes. Click “Save Permissions” to apply them.')).toBeInTheDocument();
+  });
+
+  it('saves the full draft permissions payload', async () => {
+    const onSave = vi.fn(async () => true);
+    renderPermissionsSection({ onSave });
+
+    await userEvent.selectOptions(getSelectForLabelText('Client Portal Access'), 'read_only');
+
+    const caseStatusRow = screen.getByText('Case Status').closest('div.flex.items-center.justify-between');
+    if (!(caseStatusRow instanceof HTMLElement)) {
+      throw new Error('Missing Case Status row');
+    }
+    await userEvent.click(within(caseStatusRow).getByRole('button', { name: 'Enabled' }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save Permissions' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        portal_access: 'read_only',
+        show_case_status_progress: false,
+      })
+    );
+  });
+});

--- a/frontend/tests/permissionsSection.test.tsx
+++ b/frontend/tests/permissionsSection.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { PermissionsSection } from '../figma/components/case-configuration/sections/PermissionsSection';
-import { mockCaseWorkspace, mockPortalPermissions } from '../figma/storybook/fixtures';
+import { mockPortalPermissions } from '../figma/storybook/fixtures';
 
 function renderPermissionsSection(options?: {
   portalPermissions?: typeof mockPortalPermissions;
@@ -15,7 +15,6 @@ function renderPermissionsSection(options?: {
 
   const result = render(
     <PermissionsSection
-      workspace={mockCaseWorkspace}
       portalPermissions={options?.portalPermissions ?? mockPortalPermissions}
       defaultPortalPermissions={mockPortalPermissions}
       saving={false}
@@ -67,7 +66,6 @@ describe('PermissionsSection', () => {
 
     rerender(
       <PermissionsSection
-        workspace={mockCaseWorkspace}
         portalPermissions={mockPortalPermissions}
         defaultPortalPermissions={mockPortalPermissions}
         saving={false}


### PR DESCRIPTION
Merged “Client Portal Visibility” controls into the “Access Control” area to remove overlapping settings.
Removed the non-essential “Active Case Assignments” block from Sharing/Permissions.
Updated permission labels/copy to match current client-facing sections (status, milestones, document checklist).
Kept permissions editable by default (no edit-gate), while preserving local draft behavior so polling refreshes don’t overwrite unsaved choices.
Added an unsaved-changes hint and kept save/reset behavior clear and explicit.
## Testing

Updated Storybook expectation for the merged permissions view.
Added/updated focused tests for:
default editable permissions flow
polling-safe unsaved draft behavior
permissions save payload behavior
client dashboard gating from permission settings (status visibility, limited access, upload disabled)
Ran:
npm test -- permissionsSection.test.tsx
npm test -- clientDashboard.permissions.test.tsx
