### PR TITLE
Show organization slug on invitation setup page

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -343,10 +343,20 @@ def verify_invitation(
     if user is None:
         raise HTTPException(status_code=400, detail="Invited user no longer exists")
 
+    organization = db.scalar(
+        select(Organization).where(
+            Organization.id == user.organization_id,
+            Organization.deleted_at.is_(None),
+        )
+    )
+    if organization is None:
+        raise HTTPException(status_code=400, detail="Organization no longer exists")
+
     return VerifyInvitationResponse(
         email=user.email,
         full_name=f"{user.first_name} {user.last_name}",
         organization_id=user.organization_id,
+        organization_slug=organization.slug,
         expires_at=invitation.expires_at,
     )
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -89,4 +89,5 @@ class VerifyInvitationResponse(BaseModel):
     email: str
     full_name: str
     organization_id: UUID
+    organization_slug: str
     expires_at: datetime

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -187,3 +187,32 @@ def test_accept_invitation_activates_user_and_creates_profile(monkeypatch, make_
     assert result.email == user.email
     assert user.status == 'active'
     db.commit.assert_called_once()
+
+
+def test_verify_invitation_returns_organization_slug(monkeypatch, make_user):
+    organization_id = uuid4()
+    invitation = row(
+        organization_id=organization_id,
+        user_id=uuid4(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        accepted_at=None,
+        revoked_at=None,
+    )
+    user = make_user(
+        id=invitation.user_id,
+        organization_id=organization_id,
+        email='invitee@example.com',
+        first_name='Invitee',
+        last_name='User',
+    )
+    organization = row(id=organization_id, slug='acme-law')
+    db = MagicMock()
+    db.scalar.side_effect = [invitation, user, organization]
+    monkeypatch.setattr(auth, 'hash_invitation_token', lambda token: 'token-hash')
+
+    result = auth.verify_invitation(token='a' * 16, db=db)
+
+    assert result.email == 'invitee@example.com'
+    assert result.full_name == 'Invitee User'
+    assert str(result.organization_id) == str(organization_id)
+    assert result.organization_slug == 'acme-law'

--- a/frontend/app/invite/page.tsx
+++ b/frontend/app/invite/page.tsx
@@ -130,6 +130,17 @@ function InviteForm() {
             <span className="text-gray-500">Email: </span>
             <span className="text-gray-900 font-medium">{info.email}</span>
           </p>
+          <p>
+            <span className="text-gray-500">Organization slug: </span>
+            <span className="text-gray-900 font-semibold">{info.organization_slug}</span>
+          </p>
+        </div>
+
+        <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+          <p className="text-sm text-amber-800">
+            <span className="font-semibold">Important:</span> Remember your organization slug. You will need it to
+            sign in.
+          </p>
         </div>
 
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -193,6 +193,7 @@ export type VerifyInvitationResult = {
   email: string;
   full_name: string;
   organization_id: string;
+  organization_slug: string;
   expires_at: string;
 };
 


### PR DESCRIPTION
## Summary
- add organization slug to verify-invitation response
- display organization slug on invite setup page
- add reminder note for users to remember their organization slug
- add auth route test coverage for verify-invitation