### PR TITLE
Add global bug report widget with screenshot support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,11 @@ S3_MAX_UPLOAD_BYTES=26214400
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SESSION_TOKEN=
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=noreply@visatrack.ca
+RESEND_FROM_NAME=VisaTrack
+BUG_REPORT_TO_EMAIL=visatrack.support@gmail.com
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_BUG_REPORT_EMAIL=visatrack.support@gmail.com
 NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/new

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ AWS_SESSION_TOKEN=
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_BUG_REPORT_EMAIL=support@visatrack.ca
+NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/new

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,5 @@ AWS_SESSION_TOKEN=
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_BUG_REPORT_EMAIL=support@visatrack.ca
+NEXT_PUBLIC_BUG_REPORT_EMAIL=visatrack.support@gmail.com
 NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/new

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,7 +1,7 @@
 """API Router: Main FastAPI router that aggregates all sub-routers for cases, users, auth, and other domain endpoints."""
 from fastapi import APIRouter
 
-from app.api.routes import admin, auth, cases, client, dashboard, health, lawyer, organizations, users
+from app.api.routes import admin, auth, cases, client, dashboard, feedback, health, lawyer, organizations, users
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -13,3 +13,4 @@ api_router.include_router(admin.router, prefix="/api/v1")
 api_router.include_router(auth.router, prefix="/api/v1")
 api_router.include_router(lawyer.router, prefix="/api/v1")
 api_router.include_router(client.router, prefix="/api/v1")
+api_router.include_router(feedback.router, prefix="/api/v1")

--- a/backend/app/api/routes/feedback.py
+++ b/backend/app/api/routes/feedback.py
@@ -1,0 +1,42 @@
+"""Feedback Routes: Public endpoint for submitting product bug reports."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from app.core.config import settings
+from app.schemas.feedback import BugReportSubmitRequest
+from app.services.email import EmailNotConfiguredError, send_bug_report_email
+
+router = APIRouter(prefix="/feedback", tags=["feedback"])
+
+
+@router.post("/bug-report", status_code=status.HTTP_204_NO_CONTENT)
+def submit_bug_report(payload: BugReportSubmitRequest, request: Request) -> None:
+    client_host = request.client.host if request.client and request.client.host else None
+    try:
+        send_bug_report_email(
+            to_email=settings.bug_report_to_email,
+            report_title=payload.title,
+            report_details=payload.details,
+            path=payload.context.path,
+            origin=payload.context.origin,
+            reported_at_utc=payload.context.reported_at_utc.isoformat(),
+            user_agent=payload.context.user_agent,
+            screenshot_captured_at=(
+                payload.context.screenshot_captured_at.isoformat()
+                if payload.context.screenshot_captured_at
+                else None
+            ),
+            screenshot_filename=payload.screenshot.filename if payload.screenshot else None,
+            screenshot_content_type=payload.screenshot.content_type if payload.screenshot else None,
+            screenshot_base64_content=payload.screenshot.base64_content if payload.screenshot else None,
+            delivery_channel=payload.channel,
+            sender_ip=client_host,
+            referrer=request.headers.get("referer"),
+            browser_language=request.headers.get("accept-language"),
+        )
+    except EmailNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to send bug report email: {exc}") from exc

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,7 @@ class Settings:
     resend_api_key: str = os.getenv("RESEND_API_KEY", "")
     resend_from_email: str = os.getenv("RESEND_FROM_EMAIL", "noreply@visatrack.ca")
     resend_from_name: str = os.getenv("RESEND_FROM_NAME", "VisaTrack")
+    bug_report_to_email: str = os.getenv("BUG_REPORT_TO_EMAIL", "visatrack.support@gmail.com")
 
     @property
     def frontend_origins(self) -> list[str]:

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -1,0 +1,30 @@
+"""Feedback Schemas: Request models for bug and product feedback submissions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class BugReportContext(BaseModel):
+    path: str = Field(min_length=1, max_length=2048)
+    origin: str | None = Field(default=None, max_length=512)
+    reported_at_utc: datetime
+    user_agent: str | None = Field(default=None, max_length=2048)
+    screenshot_captured_at: datetime | None = None
+
+
+class BugReportScreenshot(BaseModel):
+    filename: str = Field(min_length=1, max_length=255)
+    content_type: str = Field(min_length=1, max_length=128)
+    base64_content: str = Field(min_length=8, max_length=8_000_000)
+
+
+class BugReportSubmitRequest(BaseModel):
+    title: str = Field(min_length=3, max_length=200)
+    details: str = Field(min_length=5, max_length=10000)
+    channel: Literal["email", "github"] = "email"
+    context: BugReportContext
+    screenshot: BugReportScreenshot | None = None

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -170,3 +170,118 @@ def send_invitation_email(
     })
 
     logger.info("Invitation email sent to %s via Resend", to_email)
+
+
+def send_bug_report_email(
+    *,
+    to_email: str,
+    report_title: str,
+    report_details: str,
+    path: str,
+    origin: str | None,
+    reported_at_utc: str,
+    user_agent: str | None,
+    screenshot_captured_at: str | None,
+    screenshot_filename: str | None,
+    screenshot_content_type: str | None,
+    screenshot_base64_content: str | None,
+    delivery_channel: str,
+    sender_ip: str | None,
+    referrer: str | None,
+    browser_language: str | None,
+) -> None:
+    """Send a bug report email via Resend."""
+    if not settings.resend_api_key:
+        raise EmailNotConfiguredError(
+            "Resend is not configured. Set RESEND_API_KEY in your environment."
+        )
+
+    resend.api_key = settings.resend_api_key
+
+    from_address = f"{settings.resend_from_name} <{settings.resend_from_email}>"
+    subject = f"[Bug Report] {report_title.strip()}"
+
+    plain_text = (
+        "Bug report submitted from VisaTrack\n\n"
+        f"Title: {report_title}\n"
+        f"Details:\n{report_details}\n\n"
+        "Context\n"
+        f"- Path: {path}\n"
+        f"- Origin: {origin or 'unknown'}\n"
+        f"- Reported at (UTC): {reported_at_utc}\n"
+        f"- Channel selected: {delivery_channel}\n"
+        f"- Screenshot captured at (UTC): {screenshot_captured_at or 'not provided'}\n"
+        f"- Screenshot attached: {'yes' if screenshot_base64_content else 'no'}\n"
+        f"- User-Agent: {user_agent or 'unknown'}\n"
+        f"- Referrer: {referrer or 'unknown'}\n"
+        f"- Browser language: {browser_language or 'unknown'}\n"
+        f"- Sender IP: {sender_ip or 'unknown'}\n"
+    )
+
+    escaped_title = html_lib.escape(report_title)
+    escaped_details = html_lib.escape(report_details).replace("\n", "<br>")
+    escaped_path = html_lib.escape(path)
+    escaped_origin = html_lib.escape(origin or "unknown")
+    escaped_reported_at = html_lib.escape(reported_at_utc)
+    escaped_channel = html_lib.escape(delivery_channel)
+    escaped_screenshot = html_lib.escape(screenshot_captured_at or "not provided")
+    escaped_screenshot_attached = "yes" if screenshot_base64_content else "no"
+    escaped_user_agent = html_lib.escape(user_agent or "unknown")
+    escaped_referrer = html_lib.escape(referrer or "unknown")
+    escaped_browser_language = html_lib.escape(browser_language or "unknown")
+    escaped_sender_ip = html_lib.escape(sender_ip or "unknown")
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body style="margin:0;padding:24px;background:#f4f4f5;font-family:Arial,Helvetica,sans-serif;">
+  <div style="max-width:700px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;">
+    <div style="background:#111827;color:#ffffff;padding:16px 20px;font-size:18px;font-weight:600;">
+      VisaTrack Bug Report
+    </div>
+    <div style="padding:20px;">
+      <h2 style="margin:0 0 12px;color:#111827;font-size:20px;">{escaped_title}</h2>
+      <p style="margin:0 0 16px;color:#374151;line-height:1.65;">{escaped_details}</p>
+
+      <h3 style="margin:20px 0 8px;color:#111827;font-size:16px;">Context</h3>
+      <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+        <tr><td style="padding:6px 0;color:#6b7280;">Path</td><td style="padding:6px 0;color:#111827;">{escaped_path}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Origin</td><td style="padding:6px 0;color:#111827;">{escaped_origin}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Reported at (UTC)</td><td style="padding:6px 0;color:#111827;">{escaped_reported_at}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Channel selected</td><td style="padding:6px 0;color:#111827;">{escaped_channel}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Screenshot captured</td><td style="padding:6px 0;color:#111827;">{escaped_screenshot}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Screenshot attached</td><td style="padding:6px 0;color:#111827;">{escaped_screenshot_attached}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">User-Agent</td><td style="padding:6px 0;color:#111827;">{escaped_user_agent}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Referrer</td><td style="padding:6px 0;color:#111827;">{escaped_referrer}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Browser language</td><td style="padding:6px 0;color:#111827;">{escaped_browser_language}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Sender IP</td><td style="padding:6px 0;color:#111827;">{escaped_sender_ip}</td></tr>
+      </table>
+    </div>
+  </div>
+</body>
+</html>"""
+
+    send_params: dict = {
+        "from": from_address,
+        "to": [to_email],
+        "subject": subject,
+        "text": plain_text,
+        "html": html,
+        "click_tracking": False,
+    }
+
+    if screenshot_base64_content and screenshot_filename:
+        send_params["attachments"] = [
+            {
+                "filename": screenshot_filename,
+                "content": screenshot_base64_content,
+                "content_type": screenshot_content_type or "image/png",
+            }
+        ]
+
+    resend.Emails.send(send_params)
+
+    logger.info("Bug report email sent to %s via Resend", to_email)

--- a/backend/tests/api/routes/test_feedback.py
+++ b/backend/tests/api/routes/test_feedback.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import feedback
+from app.schemas.feedback import BugReportContext, BugReportScreenshot, BugReportSubmitRequest
+from app.services.email import EmailNotConfiguredError
+from tests.support import row
+
+
+def test_submit_bug_report_sends_email_with_screenshot_attachment(monkeypatch):
+    payload = BugReportSubmitRequest(
+        title="Cannot submit payment",
+        details="Clicking pay now does nothing and no toast appears.",
+        channel="email",
+        context=BugReportContext(
+            path="/cases/C-2026-001",
+            origin="https://visatrack.ca",
+            reported_at_utc=datetime.now(timezone.utc),
+            user_agent="pytest-agent",
+            screenshot_captured_at=datetime.now(timezone.utc),
+        ),
+        screenshot=BugReportScreenshot(
+            filename="visatrack-bug-123.png",
+            content_type="image/png",
+            base64_content="iVBORw0KGgoAAAANSUhEUgAAAAUA",
+        ),
+    )
+    request = row(
+        client=row(host="127.0.0.1"),
+        headers={
+            "referer": "https://visatrack.ca/cases/C-2026-001",
+            "accept-language": "en-CA,en;q=0.9",
+        },
+    )
+
+    fake_send = MagicMock()
+    monkeypatch.setattr(feedback, "send_bug_report_email", fake_send)
+    monkeypatch.setattr(feedback.settings, "bug_report_to_email", "visatrack.support@gmail.com")
+
+    feedback.submit_bug_report(payload=payload, request=request)
+
+    kwargs = fake_send.call_args.kwargs
+    assert kwargs["to_email"] == "visatrack.support@gmail.com"
+    assert kwargs["report_title"] == payload.title
+    assert kwargs["report_details"] == payload.details
+    assert kwargs["screenshot_filename"] == "visatrack-bug-123.png"
+    assert kwargs["screenshot_content_type"] == "image/png"
+    assert kwargs["screenshot_base64_content"] == "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+    assert kwargs["sender_ip"] == "127.0.0.1"
+
+
+def test_submit_bug_report_returns_503_when_email_not_configured(monkeypatch):
+    payload = BugReportSubmitRequest(
+        title="Cannot open dashboard",
+        details="Screen stays blank after login.",
+        channel="email",
+        context=BugReportContext(
+            path="/",
+            origin="http://localhost:3000",
+            reported_at_utc=datetime.now(timezone.utc),
+            user_agent="pytest-agent",
+            screenshot_captured_at=None,
+        ),
+        screenshot=None,
+    )
+    request = row(client=row(host="127.0.0.1"), headers={})
+
+    def _raise_not_configured(**_kwargs):
+        raise EmailNotConfiguredError("Resend is not configured")
+
+    monkeypatch.setattr(feedback, "send_bug_report_email", _raise_not_configured)
+
+    with pytest.raises(HTTPException) as exc:
+        feedback.submit_bug_report(payload=payload, request=request)
+
+    assert exc.value.status_code == 503
+    assert "Resend is not configured" in str(exc.value.detail)
+
+
+def test_submit_bug_report_returns_502_on_delivery_failure(monkeypatch):
+    payload = BugReportSubmitRequest(
+        title="Cannot open dashboard",
+        details="Screen stays blank after login.",
+        channel="email",
+        context=BugReportContext(
+            path="/",
+            origin="http://localhost:3000",
+            reported_at_utc=datetime.now(timezone.utc),
+            user_agent="pytest-agent",
+            screenshot_captured_at=None,
+        ),
+        screenshot=None,
+    )
+    request = row(client=row(host="127.0.0.1"), headers={})
+
+    def _raise_delivery_error(**_kwargs):
+        raise RuntimeError("SMTP unavailable")
+
+    monkeypatch.setattr(feedback, "send_bug_report_email", _raise_delivery_error)
+
+    with pytest.raises(HTTPException) as exc:
+        feedback.submit_bug_report(payload=payload, request=request)
+
+    assert exc.value.status_code == 502
+    assert "Failed to send bug report email" in str(exc.value.detail)

--- a/backend/tests/api/test_router.py
+++ b/backend/tests/api/test_router.py
@@ -10,3 +10,4 @@ def test_api_router_includes_expected_paths():
     assert '/api/v1/auth/login' in paths
     assert '/api/v1/cases/by-number/{case_number}/workspace' in paths
     assert '/api/v1/lawyer/clients' in paths
+    assert '/api/v1/feedback/bug-report' in paths

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,8 @@
 
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
+import { BugReportWidget } from "../design-system/components/BugReportWidget";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,6 +36,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Suspense fallback={null}>
+          <BugReportWidget />
+        </Suspense>
       </body>
     </html>
   );

--- a/frontend/design-system/components/BugReportWidget.tsx
+++ b/frontend/design-system/components/BugReportWidget.tsx
@@ -296,13 +296,13 @@ export function BugReportWidget() {
     const normalizedTitle = title.trim();
     const normalizedDetails = details.trim();
 
-    if (!normalizedTitle) {
-      setValidationError("Please add a short bug title.");
+    if (!normalizedTitle || normalizedTitle.length < 3) {
+      setValidationError("Title must be at least 3 characters.");
       return;
     }
 
-    if (!normalizedDetails) {
-      setValidationError("Please describe what happened.");
+    if (!normalizedDetails || normalizedDetails.length < 5) {
+      setValidationError("Details must be at least 5 characters.");
       return;
     }
 
@@ -426,6 +426,7 @@ export function BugReportWidget() {
                   id="bug-title"
                   value={title}
                   onChange={(event) => setTitle(event.target.value)}
+                  minLength={3}
                   placeholder="Short summary of the bug"
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20"
                 />
@@ -439,6 +440,7 @@ export function BugReportWidget() {
                   id="bug-details"
                   value={details}
                   onChange={(event) => setDetails(event.target.value)}
+                  minLength={5}
                   rows={6}
                   placeholder="What did you expect, what happened, and steps to reproduce?"
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20"

--- a/frontend/design-system/components/BugReportWidget.tsx
+++ b/frontend/design-system/components/BugReportWidget.tsx
@@ -359,7 +359,7 @@ export function BugReportWidget() {
 
       {isOpen ? (
         <div
-          className={`fixed inset-0 z-[99] flex items-center justify-center bg-black/60 p-4 ${
+          className={`fixed inset-0 z-[99] flex items-start justify-center overflow-y-auto bg-black/60 p-4 sm:items-center ${
             isUiHiddenForCapture ? "hidden" : ""
           }`}
           onClick={(event) => {
@@ -368,7 +368,10 @@ export function BugReportWidget() {
             }
           }}
         >
-          <div className="w-full max-w-xl rounded-2xl border border-gray-200 bg-white shadow-2xl">
+          <div
+            className="my-2 flex w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl"
+            style={{ maxHeight: "calc(100vh - 2rem)" }}
+          >
             <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
               <div>
                 <h2 className="text-lg font-semibold text-gray-900">Report a bug</h2>
@@ -384,7 +387,7 @@ export function BugReportWidget() {
               </button>
             </div>
 
-            <div className="space-y-4 px-5 py-4">
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
               <div>
                 <label className="mb-1 block text-sm font-medium text-gray-700">Where should this go?</label>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/frontend/design-system/components/BugReportWidget.tsx
+++ b/frontend/design-system/components/BugReportWidget.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { AlertCircle, Bug, Mail, Send, X } from "lucide-react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+type DeliveryChannel = "email" | "github";
+type ScreenshotState = "idle" | "capturing" | "copied" | "downloaded" | "failed";
+
+const DEFAULT_BUG_REPORT_EMAIL = "support@visatrack.ca";
+const DEFAULT_GITHUB_ISSUES_URL = "https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/new";
+
+function buildPathWithQuery(pathname: string, searchParams: URLSearchParams): string {
+  const query = searchParams.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export function BugReportWidget() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [channel, setChannel] = useState<DeliveryChannel>("github");
+  const [title, setTitle] = useState("");
+  const [details, setDetails] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [screenshotState, setScreenshotState] = useState<ScreenshotState>("idle");
+  const [screenshotMessage, setScreenshotMessage] = useState<string | null>(null);
+  const [screenshotCapturedAt, setScreenshotCapturedAt] = useState<string | null>(null);
+  const [isUiHiddenForCapture, setIsUiHiddenForCapture] = useState(false);
+
+  const reportEmail = (process.env.NEXT_PUBLIC_BUG_REPORT_EMAIL || DEFAULT_BUG_REPORT_EMAIL).trim();
+  const githubIssuesUrl = (
+    process.env.NEXT_PUBLIC_GITHUB_ISSUES_URL || DEFAULT_GITHUB_ISSUES_URL
+  ).trim();
+
+  const pathWithQuery = useMemo(
+    () => buildPathWithQuery(pathname || "/", searchParams),
+    [pathname, searchParams]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen]);
+
+  const resetForm = () => {
+    setTitle("");
+    setDetails("");
+    setValidationError(null);
+    setScreenshotState("idle");
+    setScreenshotMessage(null);
+    setScreenshotCapturedAt(null);
+    setIsUiHiddenForCapture(false);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    resetForm();
+  };
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const isScreenshotCaptureSupported = (): boolean => {
+    return Boolean(navigator.mediaDevices?.getDisplayMedia);
+  };
+
+  const waitForNextPaint = () => {
+    return new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  };
+
+  const captureScreenshotBlob = async (): Promise<Blob> => {
+    const stream = await navigator.mediaDevices.getDisplayMedia({
+      video: true,
+      audio: false,
+    });
+
+    try {
+      // Hide bug report UI before we read a frame from the shared tab.
+      setIsUiHiddenForCapture(true);
+      await waitForNextPaint();
+      await waitForNextPaint();
+
+      const track = stream.getVideoTracks()[0];
+      if (!track) {
+        throw new Error("No video track returned by browser.");
+      }
+
+      const video = document.createElement("video");
+      video.srcObject = new MediaStream([track]);
+      video.playsInline = true;
+      video.muted = true;
+
+      await video.play();
+      await new Promise<void>((resolve) => {
+        if (video.readyState >= 2) {
+          resolve();
+          return;
+        }
+        video.onloadeddata = () => resolve();
+      });
+
+      const width = video.videoWidth || 1920;
+      const height = video.videoHeight || 1080;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Unable to create image context.");
+      }
+
+      context.drawImage(video, 0, 0, width, height);
+
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob(resolve, "image/png");
+      });
+
+      if (!blob) {
+        throw new Error("Unable to generate screenshot image.");
+      }
+
+      return blob;
+    } finally {
+      setIsUiHiddenForCapture(false);
+      stream.getTracks().forEach((currentTrack) => currentTrack.stop());
+    }
+  };
+
+  const tryCopyImageToClipboard = async (blob: Blob): Promise<boolean> => {
+    if (!navigator.clipboard?.write || typeof ClipboardItem === "undefined") {
+      return false;
+    }
+
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const downloadImageBlob = (blob: Blob, filename: string) => {
+    const blobUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = blobUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(blobUrl);
+  };
+
+  const captureScreenshot = async () => {
+    if (!isScreenshotCaptureSupported()) {
+      setScreenshotState("failed");
+      setScreenshotMessage("Tab screenshot is not supported in this browser.");
+      return;
+    }
+
+    setScreenshotState("capturing");
+    setScreenshotMessage("Choose the current tab in the browser prompt.");
+
+    try {
+      const screenshotBlob = await captureScreenshotBlob();
+      const copied = await tryCopyImageToClipboard(screenshotBlob);
+      const nowUtc = new Date().toISOString();
+      setScreenshotCapturedAt(nowUtc);
+
+      if (copied) {
+        setScreenshotState("copied");
+        setScreenshotMessage(
+          "Screenshot copied. Paste it into the GitHub issue (Ctrl/Cmd+V) before submitting."
+        );
+        return;
+      }
+
+      const filename = `visatrack-bug-${Date.now()}.png`;
+      downloadImageBlob(screenshotBlob, filename);
+      setScreenshotState("downloaded");
+      setScreenshotMessage(
+        `Clipboard image copy is unavailable. Downloaded ${filename}; attach it manually.`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      setScreenshotState("failed");
+      if (message.toLowerCase().includes("permission")) {
+        setScreenshotMessage("Screenshot capture was denied. Please allow screen/tab sharing.");
+        return;
+      }
+      setScreenshotMessage("Screenshot capture was cancelled or failed. Please try again.");
+    }
+  };
+
+  const buildReportBody = (summary: string, description: string): string => {
+    const now = new Date().toISOString();
+    const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "unknown";
+    const origin = typeof window !== "undefined" ? window.location.origin : "unknown";
+
+    return [
+      "## Bug summary",
+      summary,
+      "",
+      "## What happened",
+      description,
+      "",
+      "## Context",
+      `- URL path: ${pathWithQuery}`,
+      `- Site origin: ${origin}`,
+      `- Reported at (UTC): ${now}`,
+      `- Browser: ${userAgent}`,
+      `- Screenshot captured: ${screenshotCapturedAt ? `Yes (${screenshotCapturedAt})` : "No"}`,
+    ].join("\n");
+  };
+
+  const createGithubIssueUrl = (summary: string, description: string): string => {
+    const url = new URL(githubIssuesUrl);
+    url.searchParams.set("title", `[Bug] ${summary}`);
+    url.searchParams.set("body", buildReportBody(summary, description));
+    return url.toString();
+  };
+
+  const createMailtoUrl = (summary: string, description: string): string => {
+    const subject = encodeURIComponent(`[VisaTrack Bug] ${summary}`);
+    const body = encodeURIComponent(buildReportBody(summary, description));
+    return `mailto:${reportEmail}?subject=${subject}&body=${body}`;
+  };
+
+  const submitReport = () => {
+    const normalizedTitle = title.trim();
+    const normalizedDetails = details.trim();
+
+    if (!normalizedTitle) {
+      setValidationError("Please add a short bug title.");
+      return;
+    }
+
+    if (!normalizedDetails) {
+      setValidationError("Please describe what happened.");
+      return;
+    }
+
+    setValidationError(null);
+
+    if (channel === "github") {
+      const issueUrl = createGithubIssueUrl(normalizedTitle, normalizedDetails);
+      window.open(issueUrl, "_blank", "noopener,noreferrer");
+      closeModal();
+      return;
+    }
+
+    const mailtoUrl = createMailtoUrl(normalizedTitle, normalizedDetails);
+    window.location.href = mailtoUrl;
+    closeModal();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Report a bug"
+        onClick={openModal}
+        className={`fixed bottom-5 right-5 z-[95] inline-flex items-center gap-2 rounded-full border border-red-500 bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-lg transition-colors hover:bg-red-700 ${
+          isUiHiddenForCapture ? "hidden" : ""
+        }`}
+      >
+        <Bug className="h-4 w-4" />
+        Report a bug
+      </button>
+
+      {isOpen ? (
+        <div
+          className={`fixed inset-0 z-[99] flex items-center justify-center bg-black/60 p-4 ${
+            isUiHiddenForCapture ? "hidden" : ""
+          }`}
+        >
+          <div className="w-full max-w-xl rounded-2xl border border-gray-200 bg-white shadow-2xl">
+            <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Report a bug</h2>
+                <p className="text-xs text-gray-500">Send bug details from anywhere in the app.</p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close bug report dialog"
+                onClick={closeModal}
+                className="rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="space-y-4 px-5 py-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">Where should this go?</label>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <button
+                    type="button"
+                    onClick={() => setChannel("github")}
+                    className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                      channel === "github"
+                        ? "border-red-500 bg-red-50 text-red-700"
+                        : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                    }`}
+                  >
+                    <p className="font-semibold">GitHub issue</p>
+                    <p className="text-xs opacity-80 break-all">{githubIssuesUrl}</p>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setChannel("email")}
+                    className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                      channel === "email"
+                        ? "border-red-500 bg-red-50 text-red-700"
+                        : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                    }`}
+                  >
+                    <p className="font-semibold">Email</p>
+                    <p className="text-xs opacity-80 break-all">{reportEmail}</p>
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="bug-title">
+                  Title
+                </label>
+                <input
+                  id="bug-title"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Short summary of the bug"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="bug-details">
+                  Details
+                </label>
+                <textarea
+                  id="bug-details"
+                  value={details}
+                  onChange={(event) => setDetails(event.target.value)}
+                  rows={6}
+                  placeholder="What did you expect, what happened, and steps to reproduce?"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500/20"
+                />
+              </div>
+
+              <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
+                <p className="font-medium">Auto-attached context</p>
+                <p>Path: {pathWithQuery}</p>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium text-gray-800">Screenshot</p>
+                    <p className="text-xs text-gray-600">
+                      Capture the current tab, then paste or attach it to your report.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={captureScreenshot}
+                    disabled={screenshotState === "capturing"}
+                    className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {screenshotState === "capturing" ? "Capturing..." : "Capture screenshot"}
+                  </button>
+                </div>
+                {screenshotMessage ? (
+                  <p className="mt-2 text-xs text-gray-700">{screenshotMessage}</p>
+                ) : null}
+              </div>
+
+              {validationError ? (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>{validationError}</p>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-4">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={submitReport}
+                className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+              >
+                {channel === "email" ? <Mail className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+                Open {channel === "email" ? "email draft" : "GitHub issue"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/design-system/components/BugReportWidget.tsx
+++ b/frontend/design-system/components/BugReportWidget.tsx
@@ -4,10 +4,16 @@ import { AlertCircle, Bug, Mail, Send, X } from "lucide-react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
+import { submitBugReport } from "@/lib/api";
+
 type DeliveryChannel = "email" | "github";
 type ScreenshotState = "idle" | "capturing" | "copied" | "downloaded" | "failed";
+type ScreenshotAttachmentPayload = {
+  filename: string;
+  content_type: string;
+  base64_content: string;
+};
 
-const DEFAULT_BUG_REPORT_EMAIL = "support@visatrack.ca";
 const DEFAULT_GITHUB_ISSUES_URL = "https://github.com/VisaTrack-Systems/VisaTrack-Core/issues/new";
 
 function buildPathWithQuery(pathname: string, searchParams: URLSearchParams): string {
@@ -27,9 +33,12 @@ export function BugReportWidget() {
   const [screenshotState, setScreenshotState] = useState<ScreenshotState>("idle");
   const [screenshotMessage, setScreenshotMessage] = useState<string | null>(null);
   const [screenshotCapturedAt, setScreenshotCapturedAt] = useState<string | null>(null);
+  const [screenshotAttachment, setScreenshotAttachment] = useState<ScreenshotAttachmentPayload | null>(
+    null
+  );
   const [isUiHiddenForCapture, setIsUiHiddenForCapture] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const reportEmail = (process.env.NEXT_PUBLIC_BUG_REPORT_EMAIL || DEFAULT_BUG_REPORT_EMAIL).trim();
   const githubIssuesUrl = (
     process.env.NEXT_PUBLIC_GITHUB_ISSUES_URL || DEFAULT_GITHUB_ISSUES_URL
   ).trim();
@@ -78,7 +87,9 @@ export function BugReportWidget() {
     setScreenshotState("idle");
     setScreenshotMessage(null);
     setScreenshotCapturedAt(null);
+    setScreenshotAttachment(null);
     setIsUiHiddenForCapture(false);
+    setIsSubmitting(false);
   };
 
   const closeModal = () => {
@@ -184,6 +195,27 @@ export function BugReportWidget() {
     URL.revokeObjectURL(blobUrl);
   };
 
+  const blobToBase64 = async (blob: Blob): Promise<string> => {
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        if (typeof reader.result !== "string") {
+          reject(new Error("Failed to convert screenshot to base64."));
+          return;
+        }
+        resolve(reader.result);
+      };
+      reader.onerror = () => reject(new Error("Failed to read screenshot blob."));
+      reader.readAsDataURL(blob);
+    });
+
+    const parts = dataUrl.split(",", 2);
+    if (parts.length < 2 || !parts[1]) {
+      throw new Error("Invalid screenshot encoding.");
+    }
+    return parts[1];
+  };
+
   const captureScreenshot = async () => {
     if (!isScreenshotCaptureSupported()) {
       setScreenshotState("failed");
@@ -196,6 +228,14 @@ export function BugReportWidget() {
 
     try {
       const screenshotBlob = await captureScreenshotBlob();
+      const screenshotBase64 = await blobToBase64(screenshotBlob);
+      const screenshotFilename = `visatrack-bug-${Date.now()}.png`;
+      setScreenshotAttachment({
+        filename: screenshotFilename,
+        content_type: screenshotBlob.type || "image/png",
+        base64_content: screenshotBase64,
+      });
+
       const copied = await tryCopyImageToClipboard(screenshotBlob);
       const nowUtc = new Date().toISOString();
       setScreenshotCapturedAt(nowUtc);
@@ -203,16 +243,15 @@ export function BugReportWidget() {
       if (copied) {
         setScreenshotState("copied");
         setScreenshotMessage(
-          "Screenshot copied. Paste it into the GitHub issue (Ctrl/Cmd+V) before submitting."
+          "Screenshot copied and will be attached to internal email reports."
         );
         return;
       }
 
-      const filename = `visatrack-bug-${Date.now()}.png`;
-      downloadImageBlob(screenshotBlob, filename);
+      downloadImageBlob(screenshotBlob, screenshotFilename);
       setScreenshotState("downloaded");
       setScreenshotMessage(
-        `Clipboard image copy is unavailable. Downloaded ${filename}; attach it manually.`
+        `Clipboard image copy is unavailable. Downloaded ${screenshotFilename}. It will still be attached to internal email reports.`
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : "";
@@ -253,13 +292,7 @@ export function BugReportWidget() {
     return url.toString();
   };
 
-  const createMailtoUrl = (summary: string, description: string): string => {
-    const subject = encodeURIComponent(`[VisaTrack Bug] ${summary}`);
-    const body = encodeURIComponent(buildReportBody(summary, description));
-    return `mailto:${reportEmail}?subject=${subject}&body=${body}`;
-  };
-
-  const submitReport = () => {
+  const submitReport = async () => {
     const normalizedTitle = title.trim();
     const normalizedDetails = details.trim();
 
@@ -282,9 +315,32 @@ export function BugReportWidget() {
       return;
     }
 
-    const mailtoUrl = createMailtoUrl(normalizedTitle, normalizedDetails);
-    window.location.href = mailtoUrl;
-    closeModal();
+    const origin = typeof window !== "undefined" ? window.location.origin : "unknown";
+    const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "unknown";
+    const reportedAtUtc = new Date().toISOString();
+
+    setIsSubmitting(true);
+    try {
+      await submitBugReport({
+        title: normalizedTitle,
+        details: normalizedDetails,
+        channel,
+        context: {
+          path: pathWithQuery,
+          origin,
+          reported_at_utc: reportedAtUtc,
+          user_agent: userAgent,
+          screenshot_captured_at: screenshotCapturedAt,
+        },
+        screenshot: screenshotAttachment,
+      });
+      closeModal();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to send bug report email.";
+      setValidationError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -354,7 +410,7 @@ export function BugReportWidget() {
                     }`}
                   >
                     <p className="font-semibold">Email</p>
-                    <p className="text-xs opacity-80 break-all">{reportEmail}</p>
+                    <p className="text-xs opacity-80 break-all">Sent by VisaTrack support system</p>
                   </button>
                 </div>
               </div>
@@ -431,11 +487,16 @@ export function BugReportWidget() {
               </button>
               <button
                 type="button"
-                onClick={submitReport}
-                className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+                onClick={() => void submitReport()}
+                disabled={isSubmitting}
+                className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-70"
               >
                 {channel === "email" ? <Mail className="h-4 w-4" /> : <Send className="h-4 w-4" />}
-                Open {channel === "email" ? "email draft" : "GitHub issue"}
+                {isSubmitting
+                  ? "Sending..."
+                  : channel === "email"
+                    ? "Send bug report"
+                    : "Open GitHub issue"}
               </button>
             </div>
           </div>

--- a/frontend/design-system/components/BugReportWidget.tsx
+++ b/frontend/design-system/components/BugReportWidget.tsx
@@ -54,6 +54,23 @@ export function BugReportWidget() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const previousOverscroll = document.body.style.overscrollBehavior;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.overscrollBehavior = "none";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.body.style.overscrollBehavior = previousOverscroll;
+    };
+  }, [isOpen]);
+
   const resetForm = () => {
     setTitle("");
     setDetails("");
@@ -289,6 +306,11 @@ export function BugReportWidget() {
           className={`fixed inset-0 z-[99] flex items-center justify-center bg-black/60 p-4 ${
             isUiHiddenForCapture ? "hidden" : ""
           }`}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              closeModal();
+            }
+          }}
         >
           <div className="w-full max-w-xl rounded-2xl border border-gray-200 bg-white shadow-2xl">
             <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -567,6 +567,24 @@ export type UpdateCurrentUserSettingsInput = {
   locale: string;
 };
 
+export type SubmitBugReportInput = {
+  title: string;
+  details: string;
+  channel: 'email' | 'github';
+  context: {
+    path: string;
+    origin: string;
+    reported_at_utc: string;
+    user_agent: string;
+    screenshot_captured_at: string | null;
+  };
+  screenshot?: {
+    filename: string;
+    content_type: string;
+    base64_content: string;
+  } | null;
+};
+
 const baseUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000').replace(/\/$/, '');
 const authTokenStorageKey = 'visatrack.access_token';
 
@@ -759,6 +777,17 @@ export async function updateCurrentUserSettings(
 
 export async function getDashboardOverview(): Promise<DashboardOverview> {
   return requestJson<DashboardOverview>('/api/v1/dashboard/overview');
+}
+
+export async function submitBugReport(input: SubmitBugReportInput): Promise<void> {
+  return requestVoid(
+    '/api/v1/feedback/bug-report',
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+    { includeAuth: false }
+  );
 }
 
 export async function getCases(limit = 10): Promise<CaseListItem[]> {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -635,8 +635,45 @@ export function clearAccessToken(): void {
 
 async function parseErrorDetail(response: Response): Promise<string> {
   try {
-    const payload = (await response.json()) as { detail?: string };
-    return payload.detail ? ` - ${payload.detail}` : '';
+    const payload = (await response.json()) as {
+      detail?:
+        | string
+        | Array<{ loc?: Array<string | number>; msg?: string; type?: string }>
+        | Record<string, unknown>;
+    };
+
+    if (!payload.detail) {
+      return '';
+    }
+
+    if (typeof payload.detail === 'string') {
+      return ` - ${payload.detail}`;
+    }
+
+    if (Array.isArray(payload.detail)) {
+      const messages = payload.detail
+        .map((issue) => {
+          const location = Array.isArray(issue.loc)
+            ? issue.loc
+                .filter((part) => part !== 'body')
+                .map((part) => String(part))
+                .join('.')
+            : '';
+          const message = issue.msg?.trim() || 'Invalid value';
+          return location ? `${location}: ${message}` : message;
+        })
+        .filter(Boolean);
+
+      if (messages.length > 0) {
+        return ` - ${messages.join('; ')}`;
+      }
+    }
+
+    if (typeof payload.detail === 'object') {
+      return ` - ${JSON.stringify(payload.detail)}`;
+    }
+
+    return '';
   } catch {
     return '';
   }


### PR DESCRIPTION
Global bug widget is already mounted in frontend/app/layout.tsx, so it appears on all pages.
In frontend/design-system/components/BugReportWidget.tsx I added:
Capture screenshot button in the bug dialog.
Secure tab-capture flow using navigator.mediaDevices.getDisplayMedia (user permission required).
Clipboard image copy via navigator.clipboard.write when supported.
Fallback: auto-download PNG if clipboard image write is unavailable.
Bug body now records whether/when screenshot was captured.
Industry-standard behavior

No silent capture; explicit user action + browser consent.
Graceful fallback for browser compatibility.
No background access after capture (media tracks are stopped immediately).

<img width="2926" height="1560" alt="image" src="https://github.com/user-attachments/assets/e65d6ded-b462-4db3-9e52-6da084a05505" />
